### PR TITLE
Pull net income calculation into its own class

### DIFF
--- a/snap_financial_factors/benefit_estimate.py
+++ b/snap_financial_factors/benefit_estimate.py
@@ -1,4 +1,5 @@
 import yaml
+from snap_financial_factors.net_income import NetIncome
 from snap_financial_factors.tests.asset_test import AssetTest
 from snap_financial_factors.tests.gross_income_test import GrossIncomeTest
 from snap_financial_factors.tests.net_income_test import NetIncomeTest
@@ -23,7 +24,9 @@ class BenefitEstimate:
         self.state_websites = yaml.safe_load(open('./program_data/state_websites.yaml', 'r'))
 
     def calculate(self):
-        """Only public method for this class. Returns eligibility information, estimated monthly benefits, and reasons behind the output.
+        """
+        Only public method for this class. Returns eligibility information,
+        estimated monthly benefits, and reasons behind the output.
 
         Returns a dictionary shaped like this:
         {
@@ -35,27 +38,30 @@ class BenefitEstimate:
         """
 
         eligibility_calculation = self.__eligibility_calculation()
-        eligible = eligibility_calculation['eligible']
+        is_eligible = eligibility_calculation['eligible']
         reasons = eligibility_calculation['reasons']
+        net_income = eligibility_calculation['net_income']
 
-        estimated_monthly_benefit = self.__estimated_monthly_benefit(eligible)
-        estimated_monthly_benefit_amount = estimated_monthly_benefit['amount']
-        estimated_monthly_benefit_reason = estimated_monthly_benefit['reason']
-        reasons.append(estimated_monthly_benefit_reason)
+        estimated_benefit = self.__estimated_monthly_benefit(is_eligible, net_income)
+        estimated_benefit_amount = estimated_benefit['amount']
+        estimated_benefit_reason = estimated_benefit['reason']
+        reasons.append(estimated_benefit_reason)
 
         state_website = self.state_websites[self.state_or_territory]
 
         return {
-            'eligible': eligible,
-            'estimated_monthly_benefit': estimated_monthly_benefit_amount,
+            'eligible': is_eligible,
+            'estimated_monthly_benefit': estimated_benefit_amount,
             'reasons': reasons,
             'state_website': state_website
             }
 
     def __eligibility_calculation(self):
-        """Private method. Returns estimated SNAP eligibility plus reasons behind the calculation.
+        """Private method. Returns estimated SNAP eligibility plus reasons
+        behind the calculation.
 
-        Mostly responsible for reading in parameters that differ by U.S. state, or passing in default federal parameters in some cases.
+        Mostly responsible for reading in parameters that differ by U.S. state,
+        or passing in default federal parameters in some cases.
 
         Returns a dictionary shaped like this:
         {
@@ -88,19 +94,28 @@ class BenefitEstimate:
             resource_limit_elderly_or_disabled,
             resource_limit_elderly_or_disabled_income_twice_fpl,
             resource_limit_non_elderly_or_disabled):
-        """Private method. Breaks eligibility determiniation into its component classes; asks each of those classes to run calculations and return reasons."""
+        """
+        Private method. Breaks eligibility determiniation into component
+        classes; asks each of those classes to run calculations and return
+        reasons.
+        """
+        input_data = self.input_data
+        deductions_data = self.deductions_data
+        income_limit_data = self.income_limit_data
+        state_or_territory = self.state_or_territory
+        household_size = self.household_size
 
-        income_limits = FetchIncomeLimits(self.state_or_territory, self.household_size, self.income_limit_data)
+        income_limits = FetchIncomeLimits(state_or_territory, household_size, income_limit_data)
 
-        net_income_test = NetIncomeTest(self.input_data,
-                                        self.deductions_data,
-                                        income_limits)
+        net_income = NetIncome(input_data, deductions_data).calculate()
 
-        asset_test = AssetTest(self.input_data,
+        net_income_test = NetIncomeTest(input_data, net_income, income_limits)
+
+        asset_test = AssetTest(input_data,
                                resource_limit_elderly_or_disabled,
                                resource_limit_non_elderly_or_disabled)
 
-        gross_income_test = GrossIncomeTest(self.input_data,
+        gross_income_test = GrossIncomeTest(input_data,
                                             income_limits,
                                             gross_income_limit_factor)
 
@@ -114,13 +129,16 @@ class BenefitEstimate:
         return {
             'eligible': overall_eligibility,
             'reasons': reasons,
+            'net_income': net_income,
         }
 
 
-    def __estimated_monthly_benefit(self, eligible):
-        """Private method. Returns estimate of monthly benefit based on input data plus reasons behind its decision."""
+    def __estimated_monthly_benefit(self, is_eligible, net_income):
+        """
+        Returns estimate of monthly benefit, plus reasons behind its decision.
+        """
 
-        if not eligible:
+        if not is_eligible:
             return {
                 'amount': 0,
                 'reason': {
@@ -130,13 +148,20 @@ class BenefitEstimate:
             }
 
         description = []
+        state_or_territory = self.state_or_territory
+        household_size = self.household_size
+        allotments_data = self.allotments_data
 
-        max_monthly_allotment = FetchAllotments(self.state_or_territory, self.household_size, self.allotments_data).max_allotment()
-        estimated_benefit = max_monthly_allotment - (self.monthly_income * 0.3)
+        fetch_allotments = FetchAllotments(state_or_territory,
+                                           household_size,
+                                           allotments_data)
+        max_monthly_allotment = fetch_allotments.max_allotment()
+
+        estimated_benefit = max_monthly_allotment - (net_income * 0.3)
 
         description.append('Max monthly allotment for state and household size: ${}.'.format(max_monthly_allotment))
-        description.append('Subtract 30 percent of monthly income to determine estimated benefit.')
-        description.append('Monthly income submitted to API: ${}.'.format(self.monthly_income))
+        description.append('Subtract 30 percent of net monthly income to determine estimated benefit.')
+        description.append('Net monthly income: ${}.'.format(net_income))
 
         if 0 > estimated_benefit:
             description.append("Eligibile, but monthly income results in zero benefit.")

--- a/snap_financial_factors/benefit_estimate.py
+++ b/snap_financial_factors/benefit_estimate.py
@@ -109,7 +109,7 @@ class BenefitEstimate:
 
         net_income = NetIncome(input_data, deductions_data).calculate()
 
-        net_income_test = NetIncomeTest(input_data, net_income, income_limits)
+        net_income_test = NetIncomeTest(net_income, income_limits)
 
         asset_test = AssetTest(input_data,
                                resource_limit_elderly_or_disabled,

--- a/snap_financial_factors/net_income.py
+++ b/snap_financial_factors/net_income.py
@@ -9,10 +9,8 @@ class NetIncome:
         # Load user input data
         self.input_data = input_data
         self.state_or_territory = input_data['state_or_territory']
-        self.monthly_income = input_data['monthly_income']
         self.household_size = input_data['household_size']
-        self.household_includes_elderly_or_disabled = input_data['household_includes_elderly_or_disabled']
-        self.resources = input_data['resources']
+        self.monthly_income = input_data['monthly_income']
 
         self.deductions_data = deductions_data
 
@@ -20,11 +18,12 @@ class NetIncome:
         state_or_territory = self.state_or_territory
         household_size = self.household_size
         deductions_data = self.deductions_data
+        monthly_income = self.monthly_income
 
         deductions = FetchDeductions(state_or_territory, household_size, deductions_data)
         standard_deduction = deductions.standard_deduction()
 
-        income_minus_deductions = self.monthly_income - standard_deduction
+        income_minus_deductions = monthly_income - standard_deduction
 
         # Adjusted net income can't be negative
         if income_minus_deductions >= 0:

--- a/snap_financial_factors/net_income.py
+++ b/snap_financial_factors/net_income.py
@@ -1,0 +1,33 @@
+from snap_financial_factors.fetch_deductions import FetchDeductions
+
+class NetIncome:
+    '''
+    Returns the adjusted net income (gross income minus deductions).
+    '''
+
+    def __init__(self, input_data, deductions_data):
+        # Load user input data
+        self.input_data = input_data
+        self.state_or_territory = input_data['state_or_territory']
+        self.monthly_income = input_data['monthly_income']
+        self.household_size = input_data['household_size']
+        self.household_includes_elderly_or_disabled = input_data['household_includes_elderly_or_disabled']
+        self.resources = input_data['resources']
+
+        self.deductions_data = deductions_data
+
+    def calculate(self):
+        state_or_territory = self.state_or_territory
+        household_size = self.household_size
+        deductions_data = self.deductions_data
+
+        deductions = FetchDeductions(state_or_territory, household_size, deductions_data)
+        standard_deduction = deductions.standard_deduction()
+
+        income_minus_deductions = self.monthly_income - standard_deduction
+
+        # Adjusted net income can't be negative
+        if income_minus_deductions >= 0:
+            return income_minus_deductions
+        else:
+            return 0

--- a/snap_financial_factors/tests/net_income_test.py
+++ b/snap_financial_factors/tests/net_income_test.py
@@ -1,5 +1,3 @@
-from snap_financial_factors.fetch_deductions import FetchDeductions
-
 class NetIncomeTest:
     '''
     Evaluates net income against the appropriate net income threshold.
@@ -10,12 +8,13 @@ class NetIncomeTest:
         self.income_limits = income_limits
 
     def calculate(self):
+        net_income = self.net_income
         net_monthly_income_limit = self.income_limits.net_monthly_income_limit()
-        below_net_income_limit = net_monthly_income_limit > self.net_income
+        below_net_income_limit = net_monthly_income_limit > net_income
 
-        description = ['Net monthly income limit for state and household size: ${}'.format(net_monthly_income_limit)]
-        description.append('Net monthly income : ${}'.format(self.net_income))
-        description.append('Eligibility factor -- Is household income (minus deductions) below net monthly income limit? {}.'.format(below_net_income_limit))
+        description = ['Net monthly income limit for state and household size: ${}.'.format(net_monthly_income_limit)]
+        description.append('Net monthly income: ${}.'.format(net_income))
+        description.append('Meets eligibility test? {}.'.format(below_net_income_limit))
 
         return {
             'result': below_net_income_limit,

--- a/snap_financial_factors/tests/net_income_test.py
+++ b/snap_financial_factors/tests/net_income_test.py
@@ -5,13 +5,7 @@ class NetIncomeTest:
     Evaluates net income against the appropriate net income threshold.
     '''
 
-    def __init__(self, input_data, net_income, income_limits):
-        self.input_data = input_data
-        self.state_or_territory = input_data['state_or_territory']
-        self.monthly_income = input_data['monthly_income']
-        self.household_size = input_data['household_size']
-        self.household_includes_elderly_or_disabled = input_data['household_includes_elderly_or_disabled']
-        self.resources = input_data['resources']
+    def __init__(self, net_income, income_limits):
         self.net_income = net_income
         self.income_limits = income_limits
 

--- a/snap_financial_factors/tests/net_income_test.py
+++ b/snap_financial_factors/tests/net_income_test.py
@@ -1,29 +1,26 @@
 from snap_financial_factors.fetch_deductions import FetchDeductions
 
 class NetIncomeTest:
-    # TODO (ARS): Deductions beyond the standard deduction.
+    '''
+    Evaluates net income against the appropriate net income threshold.
+    '''
 
-    def __init__(self, input_data, deductions_data, income_limits):
-        # Load user input data
+    def __init__(self, input_data, net_income, income_limits):
         self.input_data = input_data
         self.state_or_territory = input_data['state_or_territory']
         self.monthly_income = input_data['monthly_income']
         self.household_size = input_data['household_size']
         self.household_includes_elderly_or_disabled = input_data['household_includes_elderly_or_disabled']
         self.resources = input_data['resources']
-
-        self.deductions_data = deductions_data
+        self.net_income = net_income
         self.income_limits = income_limits
 
     def calculate(self):
-        deductions = FetchDeductions(self.state_or_territory, self.household_size, self.deductions_data)
-        standard_deduction = deductions.standard_deduction()
         net_monthly_income_limit = self.income_limits.net_monthly_income_limit()
-        below_net_income_limit = (net_monthly_income_limit) > (self.monthly_income - standard_deduction)
+        below_net_income_limit = net_monthly_income_limit > self.net_income
 
         description = ['Net monthly income limit for state and household size: ${}'.format(net_monthly_income_limit)]
-        description.append('Standard deduction for state and household size: ${}'.format(standard_deduction))
-        description.append('Monthly income submitted to API: ${}'.format(self.monthly_income))
+        description.append('Net monthly income : ${}'.format(self.net_income))
         description.append('Eligibility factor -- Is household income (minus deductions) below net monthly income limit? {}.'.format(below_net_income_limit))
 
         return {


### PR DESCRIPTION
# Notes

+ Pull net income calculation into its own class, so that we can easily share it between the `NetIncomeTest` class and the estimated monthly benefit calculation — used by both.
+ Also: trim long lines of code when I see them.