### PR TITLE
Scroll to top of screen on show results

### DIFF
--- a/templates/prescreener.html
+++ b/templates/prescreener.html
@@ -230,6 +230,7 @@
           }
           html += '</div>';
 
+          window.scrollTo(0, 0);
           return html;
       }
 


### PR DESCRIPTION
# Notes 

+ UX improvement as the number of fields on the single-page prototype prescreener form grows — user should see results immediately when they hit "Submit." 