### PR TITLE
Model child support payments deduction; improve deductions modeling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,8 @@ type-check:
 test:
 	python3 -m pipenv run behave
 
+check-all: style-check type-check test
+
 # For now.
 serve:
 	env FLASK_APP=app.py FLASK_ENV=development flask run

--- a/features/illinois.feature
+++ b/features/illinois.feature
@@ -160,3 +160,15 @@ Feature: Testing SNAP Financial Factors Web API for IL
     When we run the benefit estimator...
       Then we find the family is likely eligible
       And we find the estimated benefit is $343 per month
+
+  Scenario: Court ordered child support payments count as deduction in IL
+    Given the household is in IL
+    And a 3-person household
+    And the household does not include an elderly or disabled member
+    And the household has earned income of $500 monthly
+    And the household has other income of $500 monthly
+    And the household has assets of $0 monthly
+    And the household has court-ordered child support payments of $100 monthly
+    When we run the benefit estimator...
+      Then we find the family is likely eligible
+      And we find the estimated benefit is $319 per month

--- a/features/illinois.feature
+++ b/features/illinois.feature
@@ -160,3 +160,28 @@ Feature: Testing SNAP Financial Factors Web API for IL
     When we run the benefit estimator...
       Then we find the family is likely eligible
       And we find the estimated benefit is $343 per month
+
+  Scenario: Household passes net income test but not gross income test
+    Given the household is in IL
+    And a 3-person household
+    And the household does not include an elderly or disabled member
+    And the household has earned income of $1000 monthly
+    And the household has other income of $2000 monthly
+    And the household has assets of $1000 monthly
+    And the household has dependent care costs of $1000 monthly
+    When we run the benefit estimator...
+      Then we find the family is likely not eligible
+      And we find the estimated benefit is $0 per month
+
+  Scenario: Child support payments exclusion pushes household into eligiblity
+    Given the household is in IL
+    And a 3-person household
+    And the household does not include an elderly or disabled member
+    And the household has earned income of $1000 monthly
+    And the household has other income of $2000 monthly
+    And the household has assets of $1000 monthly
+    And the household has dependent care costs of $1000 monthly
+    And the household has court-ordered child support payments of $100 monthly
+    When we run the benefit estimator...
+      Then we find the family is likely eligible
+      And we find the estimated benefit is $19 per month

--- a/features/illinois.feature
+++ b/features/illinois.feature
@@ -184,4 +184,17 @@ Feature: Testing SNAP Financial Factors Web API for IL
     And the household has court-ordered child support payments of $100 monthly
     When we run the benefit estimator...
       Then we find the family is likely eligible
-      And we find the estimated benefit is $19 per month
+      And we find the estimated benefit is $49 per month
+
+  Scenario: More child support payments increase estimated benefit
+    Given the household is in IL
+    And a 3-person household
+    And the household does not include an elderly or disabled member
+    And the household has earned income of $1000 monthly
+    And the household has other income of $2000 monthly
+    And the household has assets of $1000
+    And the household has dependent care costs of $1000 monthly
+    And the household has court-ordered child support payments of $400 monthly
+    When we run the benefit estimator...
+      Then we find the family is likely eligible
+      And we find the estimated benefit is $139 per month

--- a/features/illinois.feature
+++ b/features/illinois.feature
@@ -160,15 +160,3 @@ Feature: Testing SNAP Financial Factors Web API for IL
     When we run the benefit estimator...
       Then we find the family is likely eligible
       And we find the estimated benefit is $343 per month
-
-  Scenario: Court ordered child support payments count as deduction in IL
-    Given the household is in IL
-    And a 3-person household
-    And the household does not include an elderly or disabled member
-    And the household has earned income of $500 monthly
-    And the household has other income of $500 monthly
-    And the household has assets of $0 monthly
-    And the household has court-ordered child support payments of $100 monthly
-    When we run the benefit estimator...
-      Then we find the family is likely eligible
-      And we find the estimated benefit is $319 per month

--- a/features/illinois.feature
+++ b/features/illinois.feature
@@ -19,7 +19,7 @@ Feature: Testing SNAP Financial Factors Web API for IL
     And the household does not include an elderly or disabled member
     And the household has earned income of $0 monthly
     And the household has other income of $0 monthly
-    And the household has assets of $0 monthly
+    And the household has assets of $0
     When we run the benefit estimator...
       Then we find the family is likely eligible
       And we find the estimated benefit is $194 per month
@@ -30,7 +30,7 @@ Feature: Testing SNAP Financial Factors Web API for IL
     And the household does not include an elderly or disabled member
     And the household has earned income of $0 monthly
     And the household has other income of $0 monthly
-    And the household has assets of $0 monthly
+    And the household has assets of $0
     When we run the benefit estimator...
       Then we find the family is likely eligible
       And we find the estimated benefit is $355 per month
@@ -41,7 +41,7 @@ Feature: Testing SNAP Financial Factors Web API for IL
     And the household does not include an elderly or disabled member
     And the household has earned income of $0 monthly
     And the household has other income of $0 monthly
-    And the household has assets of $0 monthly
+    And the household has assets of $0
     When we run the benefit estimator...
       Then we find the family is likely eligible
       And we find the estimated benefit is $509 per month
@@ -52,7 +52,7 @@ Feature: Testing SNAP Financial Factors Web API for IL
     And the household does not include an elderly or disabled member
     And the household has earned income of $0 monthly
     And the household has other income of $2000 monthly
-    And the household has assets of $0 monthly
+    And the household has assets of $0
     When we run the benefit estimator...
       Then we find the family is likely not eligible
       And we find the estimated benefit is $0 per month
@@ -63,7 +63,7 @@ Feature: Testing SNAP Financial Factors Web API for IL
     And the household does not include an elderly or disabled member
     And the household has earned income of $0 monthly
     And the household has other income of $1040 monthly
-    And the household has assets of $0 monthly
+    And the household has assets of $0
     When we run the benefit estimator...
       Then we find the family is likely eligible
       And we find the estimated benefit is $16 per month
@@ -74,7 +74,7 @@ Feature: Testing SNAP Financial Factors Web API for IL
     And the household does not include an elderly or disabled member
     And the household has earned income of $0 monthly
     And the household has other income of $2323 monthly
-    And the household has assets of $0 monthly
+    And the household has assets of $0
     When we run the benefit estimator...
       Then we find the family is likely eligible
       And we find the estimated benefit is $2 per month
@@ -85,7 +85,7 @@ Feature: Testing SNAP Financial Factors Web API for IL
     And the household does not include an elderly or disabled member
     And the household has earned income of $1000 monthly
     And the household has other income of $0 monthly
-    And the household has assets of $0 monthly
+    And the household has assets of $0
     When we run the benefit estimator...
       Then we find the family is likely eligible
       And we find the estimated benefit is $319 per month
@@ -96,7 +96,7 @@ Feature: Testing SNAP Financial Factors Web API for IL
     And the household does not include an elderly or disabled member
     And the household has earned income of $500 monthly
     And the household has other income of $500 monthly
-    And the household has assets of $0 monthly
+    And the household has assets of $0
     When we run the benefit estimator...
       Then we find the family is likely eligible
       And we find the estimated benefit is $289 per month
@@ -107,7 +107,7 @@ Feature: Testing SNAP Financial Factors Web API for IL
     And the household does not include an elderly or disabled member
     And the household has earned income of $500 monthly
     And the household has other income of $500 monthly
-    And the household has assets of $0 monthly
+    And the household has assets of $0
     And the household has dependent care costs of $100 monthly
     When we run the benefit estimator...
       Then we find the family is likely eligible
@@ -119,7 +119,7 @@ Feature: Testing SNAP Financial Factors Web API for IL
     And the household does include an elderly or disabled member
     And the household has earned income of $400 monthly
     And the household has other income of $400 monthly
-    And the household has assets of $0 monthly
+    And the household has assets of $0
     And the household has medical expenses for elderly or disabled members of $0 monthly
     When we run the benefit estimator...
       Then we find the family is likely eligible
@@ -131,7 +131,7 @@ Feature: Testing SNAP Financial Factors Web API for IL
     And the household does include an elderly or disabled member
     And the household has earned income of $400 monthly
     And the household has other income of $400 monthly
-    And the household has assets of $0 monthly
+    And the household has assets of $0
     And the household has medical expenses for elderly or disabled members of $35 monthly
     When we run the benefit estimator...
       Then we find the family is likely eligible
@@ -143,7 +143,7 @@ Feature: Testing SNAP Financial Factors Web API for IL
     And the household does include an elderly or disabled member
     And the household has earned income of $400 monthly
     And the household has other income of $400 monthly
-    And the household has assets of $0 monthly
+    And the household has assets of $0
     And the household has medical expenses for elderly or disabled members of $135 monthly
     When we run the benefit estimator...
       Then we find the family is likely eligible
@@ -155,7 +155,7 @@ Feature: Testing SNAP Financial Factors Web API for IL
     And the household does not include an elderly or disabled member
     And the household has earned income of $400 monthly
     And the household has other income of $400 monthly
-    And the household has assets of $0 monthly
+    And the household has assets of $0
     And the household has medical expenses for elderly or disabled members of $135 monthly
     When we run the benefit estimator...
       Then we find the family is likely eligible
@@ -167,7 +167,7 @@ Feature: Testing SNAP Financial Factors Web API for IL
     And the household does not include an elderly or disabled member
     And the household has earned income of $1000 monthly
     And the household has other income of $2000 monthly
-    And the household has assets of $1000 monthly
+    And the household has assets of $1000
     And the household has dependent care costs of $1000 monthly
     When we run the benefit estimator...
       Then we find the family is likely not eligible
@@ -179,7 +179,7 @@ Feature: Testing SNAP Financial Factors Web API for IL
     And the household does not include an elderly or disabled member
     And the household has earned income of $1000 monthly
     And the household has other income of $2000 monthly
-    And the household has assets of $1000 monthly
+    And the household has assets of $1000
     And the household has dependent care costs of $1000 monthly
     And the household has court-ordered child support payments of $100 monthly
     When we run the benefit estimator...

--- a/features/illinois.feature
+++ b/features/illinois.feature
@@ -173,7 +173,7 @@ Feature: Testing SNAP Financial Factors Web API for IL
       Then we find the family is likely not eligible
       And we find the estimated benefit is $0 per month
 
-  Scenario: Child support payments exclusion pushes household into eligiblity
+  Scenario: Child support payments exclusion pushes household into eligibility
     Given the household is in IL
     And a 3-person household
     And the household does not include an elderly or disabled member

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -26,7 +26,7 @@ def step_impl(context, number):
 def step_impl(context, number):
     context.input_data['monthly_non_job_income'] = number
 
-@given('the household has assets of ${number:d} monthly')
+@given('the household has assets of ${number:d}')
 def step_impl(context, number):
     context.input_data['resources'] = number
 

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -38,7 +38,7 @@ def step_impl(context, number):
 def step_impl(context, number):
     context.input_data['medical_expenses_for_elderly_or_disabled'] = number
 
-@given('the household has court-orderd child support payments of ${number:d} monthly')
+@given('the household has court-ordered child support payments of ${number:d} monthly')
 def step_impl(context, number):
     context.input_data['court_ordered_child_support_payments'] = number
 

--- a/features/steps/steps.py
+++ b/features/steps/steps.py
@@ -38,6 +38,10 @@ def step_impl(context, number):
 def step_impl(context, number):
     context.input_data['medical_expenses_for_elderly_or_disabled'] = number
 
+@given('the household has court-orderd child support payments of ${number:d} monthly')
+def step_impl(context, number):
+    context.input_data['court_ordered_child_support_payments'] = number
+
 @when('we run the benefit estimator...')
 def step_impl(context):
     benefit_estimate = BenefitEstimate(context.input_data)

--- a/features/utah.feature
+++ b/features/utah.feature
@@ -6,7 +6,7 @@ Feature: Testing SNAP Financial Factors Web API for UT
     And the household does not include an elderly or disabled member
     And the household has earned income of $0 monthly
     And the household has other income of $0 monthly
-    And the household has assets of $0 monthly
+    And the household has assets of $0
     When we run the benefit estimator...
       Then we find the family is likely eligible
       And we find the estimated benefit is $194 per month
@@ -17,7 +17,7 @@ Feature: Testing SNAP Financial Factors Web API for UT
     And the household does not include an elderly or disabled member
     And the household has earned income of $1000 monthly
     And the household has other income of $2000 monthly
-    And the household has assets of $1000 monthly
+    And the household has assets of $1000
     And the household has dependent care costs of $1000 monthly
     When we run the benefit estimator...
       Then we find the family is likely not eligible
@@ -29,7 +29,7 @@ Feature: Testing SNAP Financial Factors Web API for UT
     And the household does not include an elderly or disabled member
     And the household has earned income of $1000 monthly
     And the household has other income of $2000 monthly
-    And the household has assets of $1000 monthly
+    And the household has assets of $1000
     And the household has dependent care costs of $1000 monthly
     And the household has court-ordered child support payments of $100 monthly
     When we run the benefit estimator...

--- a/features/utah.feature
+++ b/features/utah.feature
@@ -15,8 +15,8 @@ Feature: Testing SNAP Financial Factors Web API for UT
     Given the household is in UT
     And a 3-person household
     And the household does not include an elderly or disabled member
-    And the household has earned income of $1000 monthly
-    And the household has other income of $2000 monthly
+    And the household has earned income of $0 monthly
+    And the household has other income of $2400 monthly
     And the household has assets of $1000
     And the household has dependent care costs of $1000 monthly
     When we run the benefit estimator...
@@ -27,8 +27,8 @@ Feature: Testing SNAP Financial Factors Web API for UT
     Given the household is in UT
     And a 3-person household
     And the household does not include an elderly or disabled member
-    And the household has earned income of $1000 monthly
-    And the household has other income of $2000 monthly
+    And the household has earned income of $0 monthly
+    And the household has other income of $2400 monthly
     And the household has assets of $1000
     And the household has dependent care costs of $1000 monthly
     And the household has court-ordered child support payments of $100 monthly

--- a/features/utah.feature
+++ b/features/utah.feature
@@ -1,0 +1,24 @@
+Feature: Testing SNAP Financial Factors Web API for UT
+
+  Scenario:
+    Given the household is in UT
+    And a 1-person household
+    And the household does not include an elderly or disabled member
+    And the household has earned income of $0 monthly
+    And the household has other income of $0 monthly
+    And the household has assets of $0 monthly
+    When we run the benefit estimator...
+      Then we find the family is likely eligible
+      And we find the estimated benefit is $194 per month
+
+  Scenario: Household passes net income test but not gross income test
+    Given the household is in IL
+    And a 3-person household
+    And the household does not include an elderly or disabled member
+    And the household has earned income of $1000 monthly
+    And the household has other income of $2000 monthly
+    And the household has assets of $1000 monthly
+    And the household has dependent care costs of $1000 monthly
+    When we run the benefit estimator...
+      Then we find the family is likely not eligible
+      And we find the estimated benefit is $0 per month

--- a/features/utah.feature
+++ b/features/utah.feature
@@ -12,13 +12,26 @@ Feature: Testing SNAP Financial Factors Web API for UT
       And we find the estimated benefit is $194 per month
 
   Scenario: Household passes net income test but not gross income test
-    Given the household is in IL
+    Given the household is in UT
     And a 3-person household
     And the household does not include an elderly or disabled member
     And the household has earned income of $1000 monthly
     And the household has other income of $2000 monthly
     And the household has assets of $1000 monthly
     And the household has dependent care costs of $1000 monthly
+    When we run the benefit estimator...
+      Then we find the family is likely not eligible
+      And we find the estimated benefit is $0 per month
+
+  Scenario: Child support payments deduction does not push household into eligibility
+    Given the household is in UT
+    And a 3-person household
+    And the household does not include an elderly or disabled member
+    And the household has earned income of $1000 monthly
+    And the household has other income of $2000 monthly
+    And the household has assets of $1000 monthly
+    And the household has dependent care costs of $1000 monthly
+    And the household has court-ordered child support payments of $100 monthly
     When we run the benefit estimator...
       Then we find the family is likely not eligible
       And we find the estimated benefit is $0 per month

--- a/notes/modeling_progress.md
+++ b/notes/modeling_progress.md
@@ -6,7 +6,7 @@
 | Earned Income Deduction     | 2/24/2020    | :ballot_box_with_check:  | 2/26/2020             |
 | Dependent Care Deduction    | 2/24/2020    | :ballot_box_with_check:  | 2/26/2020             |
 | Medical Expenses Deduction  | 2/24/2020    | :ballot_box_with_check:  | 2/27/2020             |
-| Child Support Payments      | 2/24/2020    |                          |                       |
+| Child Support Payments      | 2/24/2020    | :ballot_box_with_check:  | 3/6/2020              |
 | Standard Shelter Deduction  | 2/24/2020    |                          |                       |
 | Excess Shelter Costs        | 2/24/2020    |                          |                       |
 | Elderly/Disabled 2x FPL     | 2/24/2020    |                          |                       |

--- a/program_data/state_options.yaml
+++ b/program_data/state_options.yaml
@@ -33,6 +33,7 @@ IL:
         resource_limit_elderly_or_disabled: NULL
         resource_limit_elderly_or_disabled_income_twice_fpl: 3500
         resource_limit_non_elderly_or_disabled: NULL
+        child_support_payments_deductible: True
 MA:
     2020:
         uses_bbce: True

--- a/program_data/state_options.yaml
+++ b/program_data/state_options.yaml
@@ -1,7 +1,15 @@
-# SOURCE:
-# https://fns-prod.azureedge.net/sites/default/files/resource-files/BBCE2019%28December%29.pdf
+# NOTE: This YAML file is currently incomplete and is being written by hand,
+# based on the following sources from USDA.
 
-# NOTE: This YAML file is currently incomplete and is being written by hand based on sources from SNAP.
+# SOURCES:
+#
+# "Broad-Based Community Eligibility", USDA, last updated December 2019:
+# https://fns-prod.azureedge.net/sites/default/files/resource-files/BBCE2019%28December%29.pdf
+#
+# "State Options Report", USDA, Options as of October 1, 2017:
+#
+# https://fns-prod.azureedge.net/sites/default/files/snap/14-State-Options.pdf
+
 
 AZ:
     2020:

--- a/program_data/state_options.yaml
+++ b/program_data/state_options.yaml
@@ -11,14 +11,6 @@
 # https://fns-prod.azureedge.net/sites/default/files/snap/14-State-Options.pdf
 
 
-AZ:
-    2020:
-        uses_bbce: True
-        gross_income_limit_factor: 1.85
-        resource_limit_elderly_or_disabled: NULL
-        resource_limit_elderly_or_disabled_income_twice_fpl: NULL
-        resource_limit_non_elderly_or_disabled: NULL
-
 CA:
     2020:
         uses_bbce: True
@@ -26,6 +18,7 @@ CA:
         resource_limit_elderly_or_disabled: NULL
         resource_limit_elderly_or_disabled_income_twice_fpl: NULL
         resource_limit_non_elderly_or_disabled: NULL
+        child_support_payments: EXCLUDE  # According to USDA State Options Report. Options as of October 1, 2017.
 
 ID:
     2020:
@@ -34,6 +27,7 @@ ID:
         resource_limit_elderly_or_disabled: 5000
         resource_limit_elderly_or_disabled_income_twice_fpl: 5000
         resource_limit_non_elderly_or_disabled: 5000
+        child_support_payments: DEDUCT  # According to USDA State Options Report. Options as of October 1, 2017.
 IL:
     2020:
         uses_bbce: True
@@ -41,7 +35,7 @@ IL:
         resource_limit_elderly_or_disabled: NULL
         resource_limit_elderly_or_disabled_income_twice_fpl: 3500
         resource_limit_non_elderly_or_disabled: NULL
-        child_support_payments_deductible: True
+        child_support_payments: EXCLUDE  # According to USDA State Options Report. Options as of October 1, 2017.
 MA:
     2020:
         uses_bbce: True
@@ -49,6 +43,9 @@ MA:
         resource_limit_elderly_or_disabled: NULL
         resource_limit_elderly_or_disabled_income_twice_fpl: 3500
         resource_limit_non_elderly_or_disabled: NULL
+        child_support_payments: DEDUCT  # According to USDA State Options Report. Options as of October 1, 2017.
+
 UT:
     2020:
         uses_bbce: False
+        child_support_payments: DEDUCT  # According to USDA State Options Report. Options as of October 1, 2017.

--- a/program_data/state_options.yaml
+++ b/program_data/state_options.yaml
@@ -18,7 +18,7 @@ CA:
         resource_limit_elderly_or_disabled: NULL
         resource_limit_elderly_or_disabled_income_twice_fpl: NULL
         resource_limit_non_elderly_or_disabled: NULL
-        child_support_payments: EXCLUDE  # According to USDA State Options Report. Options as of October 1, 2017.
+        child_support_payments_treatment: EXCLUDE  # According to USDA State Options Report. Options as of October 1, 2017.
 
 ID:
     2020:
@@ -27,7 +27,7 @@ ID:
         resource_limit_elderly_or_disabled: 5000
         resource_limit_elderly_or_disabled_income_twice_fpl: 5000
         resource_limit_non_elderly_or_disabled: 5000
-        child_support_payments: DEDUCT  # According to USDA State Options Report. Options as of October 1, 2017.
+        child_support_payments_treatment: DEDUCT  # According to USDA State Options Report. Options as of October 1, 2017.
 IL:
     2020:
         uses_bbce: True
@@ -35,7 +35,7 @@ IL:
         resource_limit_elderly_or_disabled: NULL
         resource_limit_elderly_or_disabled_income_twice_fpl: 3500
         resource_limit_non_elderly_or_disabled: NULL
-        child_support_payments: EXCLUDE  # According to USDA State Options Report. Options as of October 1, 2017.
+        child_support_payments_treatment: EXCLUDE  # According to USDA State Options Report. Options as of October 1, 2017.
 MA:
     2020:
         uses_bbce: True
@@ -43,9 +43,9 @@ MA:
         resource_limit_elderly_or_disabled: NULL
         resource_limit_elderly_or_disabled_income_twice_fpl: 3500
         resource_limit_non_elderly_or_disabled: NULL
-        child_support_payments: DEDUCT  # According to USDA State Options Report. Options as of October 1, 2017.
+        child_support_payments_treatment: DEDUCT  # According to USDA State Options Report. Options as of October 1, 2017.
 
 UT:
     2020:
         uses_bbce: False
-        child_support_payments: DEDUCT  # According to USDA State Options Report. Options as of October 1, 2017.
+        child_support_payments_treatment: DEDUCT  # According to USDA State Options Report. Options as of October 1, 2017.

--- a/snap_financial_factors/benefit_estimate.py
+++ b/snap_financial_factors/benefit_estimate.py
@@ -117,6 +117,7 @@ class BenefitEstimate:
         gross_income = gross_income_calculation.result
 
         net_income_calculator = NetIncome(input_data,
+                                          gross_income,
                                           deductions_data,
                                           child_support_payments_treatment)
 

--- a/snap_financial_factors/benefit_estimate.py
+++ b/snap_financial_factors/benefit_estimate.py
@@ -93,7 +93,7 @@ class BenefitEstimate:
                 resource_limit_elderly_or_disabled=3500,
                 resource_limit_elderly_or_disabled_income_twice_fpl=3500,
                 resource_limit_non_elderly_or_disabled=2250,
-                child_support_payments_deductible=False
+                child_support_payments_deductible=state_options['child_support_payments_deductible']
             )
 
     def __eligibility_calculation_with_params(self,
@@ -113,8 +113,6 @@ class BenefitEstimate:
         state_or_territory = self.state_or_territory
         household_size = self.household_size
 
-        income_limits = FetchIncomeLimits(state_or_territory, household_size, income_limit_data)
-
         net_income_calculator = NetIncome(input_data,
                                           deductions_data,
                                           child_support_payments_deductible)
@@ -123,6 +121,7 @@ class BenefitEstimate:
         net_income = net_income_calculation['result']
         net_income_reason = net_income_calculation['reason']
 
+        income_limits = FetchIncomeLimits(state_or_territory, household_size, income_limit_data)
         net_income_test = NetIncomeTest(net_income, income_limits)
 
         asset_test = AssetTest(input_data,
@@ -131,7 +130,8 @@ class BenefitEstimate:
 
         gross_income_test = GrossIncomeTest(input_data,
                                             income_limits,
-                                            gross_income_limit_factor)
+                                            gross_income_limit_factor,
+                                            child_support_payments_deductible)
 
         tests = [net_income_test, asset_test, gross_income_test]
 

--- a/snap_financial_factors/benefit_estimate.py
+++ b/snap_financial_factors/benefit_estimate.py
@@ -1,5 +1,4 @@
 import yaml
-import json
 
 from snap_financial_factors.income.net_income import NetIncome
 from snap_financial_factors.income.gross_income import GrossIncome

--- a/snap_financial_factors/benefit_estimate.py
+++ b/snap_financial_factors/benefit_estimate.py
@@ -84,6 +84,7 @@ class BenefitEstimate:
                 state_options['resource_limit_elderly_or_disabled'],
                 state_options['resource_limit_elderly_or_disabled_income_twice_fpl'],
                 state_options['resource_limit_non_elderly_or_disabled'],
+                state_options['child_support_payments_deductible']
             )
         else:
             # SNAP federal policy defaults
@@ -92,13 +93,15 @@ class BenefitEstimate:
                 resource_limit_elderly_or_disabled=3500,
                 resource_limit_elderly_or_disabled_income_twice_fpl=3500,
                 resource_limit_non_elderly_or_disabled=2250,
+                child_support_payments_deductible=False
             )
 
     def __eligibility_calculation_with_params(self,
                                               gross_income_limit_factor,
                                               resource_limit_elderly_or_disabled,
                                               resource_limit_elderly_or_disabled_income_twice_fpl,
-                                              resource_limit_non_elderly_or_disabled):
+                                              resource_limit_non_elderly_or_disabled,
+                                              child_support_payments_deductible):
         """
         Private method. Breaks eligibility determiniation into component
         classes; asks each of those classes to run calculations and return
@@ -112,7 +115,11 @@ class BenefitEstimate:
 
         income_limits = FetchIncomeLimits(state_or_territory, household_size, income_limit_data)
 
-        net_income_calculation = NetIncome(input_data, deductions_data).calculate()
+        net_income_calculator = NetIncome(input_data,
+                                          deductions_data,
+                                          child_support_payments_deductible)
+
+        net_income_calculation = net_income_calculator.calculate()
         net_income = net_income_calculation['result']
         net_income_reason = net_income_calculation['reason']
 

--- a/snap_financial_factors/benefit_estimate.py
+++ b/snap_financial_factors/benefit_estimate.py
@@ -84,7 +84,7 @@ class BenefitEstimate:
                 state_options['resource_limit_elderly_or_disabled'],
                 state_options['resource_limit_elderly_or_disabled_income_twice_fpl'],
                 state_options['resource_limit_non_elderly_or_disabled'],
-                state_options['child_support_payments_deductible']
+                state_options['child_support_payments']
             )
         else:
             # SNAP federal policy defaults
@@ -93,7 +93,7 @@ class BenefitEstimate:
                 resource_limit_elderly_or_disabled=3500,
                 resource_limit_elderly_or_disabled_income_twice_fpl=3500,
                 resource_limit_non_elderly_or_disabled=2250,
-                child_support_payments_deductible=state_options['child_support_payments_deductible']
+                child_support_payments=state_options['child_support_payments']
             )
 
     def __eligibility_calculation_with_params(self,
@@ -101,7 +101,7 @@ class BenefitEstimate:
                                               resource_limit_elderly_or_disabled,
                                               resource_limit_elderly_or_disabled_income_twice_fpl,
                                               resource_limit_non_elderly_or_disabled,
-                                              child_support_payments_deductible):
+                                              child_support_payments):
         """
         Private method. Breaks eligibility determiniation into component
         classes; asks each of those classes to run calculations and return
@@ -112,6 +112,15 @@ class BenefitEstimate:
         income_limit_data = self.income_limit_data
         state_or_territory = self.state_or_territory
         household_size = self.household_size
+
+        if child_support_payments == 'DEDUCT':
+            child_support_payments_deductible = True
+        elif child_support_payments == 'EXCLUDE':
+            child_support_payments_deductible = False
+        else:
+            raise ValueError(
+                'Unknown value for handling court-orderedchild support payments.'
+            )
 
         net_income_calculator = NetIncome(input_data,
                                           deductions_data,

--- a/snap_financial_factors/benefit_estimate.py
+++ b/snap_financial_factors/benefit_estimate.py
@@ -1,4 +1,5 @@
 import yaml
+import json
 
 from snap_financial_factors.income.net_income import NetIncome
 from snap_financial_factors.income.gross_income import GrossIncome
@@ -42,20 +43,19 @@ class BenefitEstimate:
 
         eligibility_calculation = self.__eligibility_calculation()
         is_eligible = eligibility_calculation['eligible']
-        names_and_explanations = eligibility_calculation['names_and_explanations']
+        eligibility_factors = eligibility_calculation['eligibility_factors']
         net_income = eligibility_calculation['net_income']
 
         estimated_benefit = self.__estimated_monthly_benefit(is_eligible, net_income)
         estimated_benefit_amount = estimated_benefit.amount
-        estimated_benefit_reason = estimated_benefit.name_and_explanation
-        names_and_explanations.append(estimated_benefit_reason)
+        eligibility_factors.append(estimated_benefit.__dict__)
 
         state_website = self.state_websites[self.state_or_territory]
 
         return {
             'eligible': is_eligible,
             'estimated_monthly_benefit': estimated_benefit_amount,
-            'names_and_explanations': names_and_explanations,
+            'eligibility_factors': eligibility_factors,
             'state_website': state_website
             }
 
@@ -142,15 +142,17 @@ class BenefitEstimate:
         test_results = [calculation.result for calculation in test_calculations]
         overall_eligibility = all(test_results)
 
-        names_and_explanations = [
-            calculation.name_and_explanation for calculation in test_calculations
+        eligibility_factor_classes = (
+            test_calculations + [gross_income_calculation, net_income_calculation]
+        )
+
+        eligibility_factors = [
+            factor.__dict__ for factor in eligibility_factor_classes
         ]
-        names_and_explanations.append(gross_income_calculation.name_and_explanation)
-        names_and_explanations.append(net_income_calculation.name_and_explanation)
 
         return {
             'eligible': overall_eligibility,
-            'names_and_explanations': names_and_explanations,
+            'eligibility_factors': eligibility_factors,
             'net_income': net_income,
         }
 

--- a/snap_financial_factors/calculations/benefit_amount_estimate.py
+++ b/snap_financial_factors/calculations/benefit_amount_estimate.py
@@ -1,5 +1,6 @@
 from snap_financial_factors.program_data_api.fetch_max_allotments import FetchMaxAllotments
 from snap_financial_factors.program_data_api.fetch_min_allotments import FetchMinAllotments
+from snap_financial_factors.calculations.benefit_amount_result import BenefitAmountResult
 
 
 class BenefitAmountEstimate:
@@ -19,13 +20,12 @@ class BenefitAmountEstimate:
 
     def calculate(self):
         if not self.is_eligible:
-            return {
-                'amount': 0,
-                'reason': {
-                    'test_name': 'Estimated Benefit Calculation',
-                    'description': ['Likely not eligible for SNAP.']
-                }
-            }
+            return BenefitAmountResult(
+                test_name='Estimated Benefit Calculation',
+                amount=0,
+                explanation=['Likely not eligible for SNAP.'],
+                sort_order=5
+            )
 
         explanation_intro = (
             'To determine the estimated amount of SNAP benefit, we start ' +
@@ -92,11 +92,9 @@ class BenefitAmountEstimate:
         )
         explanation.append(final_amount_explanation)
 
-        return {
-            'amount': estimated_benefit,
-            'reason': {
-                'test_name': 'Estimated Benefit Calculation',
-                'description': explanation,
-                'sort_order': 4
-            }
-        }
+        return BenefitAmountResult(
+            test_name='Estimated Benefit Calculation',
+            amount=estimated_benefit,
+            explanation=explanation,
+            sort_order=5
+        )

--- a/snap_financial_factors/calculations/benefit_amount_estimate.py
+++ b/snap_financial_factors/calculations/benefit_amount_estimate.py
@@ -21,7 +21,7 @@ class BenefitAmountEstimate:
     def calculate(self):
         if not self.is_eligible:
             return BenefitAmountResult(
-                test_name='Estimated Benefit Calculation',
+                name='Estimated Benefit Calculation',
                 amount=0,
                 explanation=['Likely not eligible for SNAP.'],
                 sort_order=5
@@ -93,7 +93,7 @@ class BenefitAmountEstimate:
         explanation.append(final_amount_explanation)
 
         return BenefitAmountResult(
-            test_name='Estimated Benefit Calculation',
+            name='Estimated Benefit Calculation',
             amount=estimated_benefit,
             explanation=explanation,
             sort_order=5

--- a/snap_financial_factors/calculations/benefit_amount_result.py
+++ b/snap_financial_factors/calculations/benefit_amount_result.py
@@ -4,6 +4,9 @@ from typing import List
 class BenefitAmountResult:
     '''
     Expresses the result of a SNAP benefit amount estimate test.
+
+    Duck types with IncomeResult and TestResult across `name`,
+    `explanation`, and `sort_order`.
     '''
 
     def __init__(self,

--- a/snap_financial_factors/calculations/benefit_amount_result.py
+++ b/snap_financial_factors/calculations/benefit_amount_result.py
@@ -7,11 +7,11 @@ class BenefitAmountResult:
     '''
 
     def __init__(self,
-                 test_name: str,
+                 name: str,
                  amount: int,
                  explanation: List[str],
                  sort_order: int) -> None:
-        self.test_name = test_name
+        self.name = name
         self.amount = amount
         self.explanation = explanation
         self.sort_order = sort_order

--- a/snap_financial_factors/calculations/benefit_amount_result.py
+++ b/snap_financial_factors/calculations/benefit_amount_result.py
@@ -15,7 +15,3 @@ class BenefitAmountResult:
         self.amount = amount
         self.explanation = explanation
         self.sort_order = sort_order
-        self.name_and_explanation = {
-            'name': test_name,
-            'explanation': explanation,
-        }

--- a/snap_financial_factors/calculations/benefit_amount_result.py
+++ b/snap_financial_factors/calculations/benefit_amount_result.py
@@ -1,0 +1,18 @@
+from typing import List
+
+
+class BenefitAmountResult:
+    '''
+    Expresses the result of a SNAP benefit amount estimate test.
+    '''
+
+    def __init__(self,
+                 test_name: str,
+                 amount: int,
+                 explanation: List[str],
+                 sort_order: int) -> None:
+
+        self.test_name = test_name
+        self.amount = amount
+        self.explanation = explanation
+        self.sort_order = sort_order

--- a/snap_financial_factors/calculations/benefit_amount_result.py
+++ b/snap_financial_factors/calculations/benefit_amount_result.py
@@ -11,8 +11,11 @@ class BenefitAmountResult:
                  amount: int,
                  explanation: List[str],
                  sort_order: int) -> None:
-
         self.test_name = test_name
         self.amount = amount
         self.explanation = explanation
         self.sort_order = sort_order
+        self.name_and_explanation = {
+            'name': test_name,
+            'explanation': explanation,
+        }

--- a/snap_financial_factors/calculations/net_income.py
+++ b/snap_financial_factors/calculations/net_income.py
@@ -1,9 +1,9 @@
 from typing import Dict
-from snap_financial_factors.program_data_api.fetch_deductions import FetchDeductions
 from snap_financial_factors.deductions.earned_income_deduction import EarnedIncomeDeduction
 from snap_financial_factors.deductions.dependent_care_deduction import DependentCareDeduction
 from snap_financial_factors.deductions.medical_expenses_deduction import MedicalExpensesDeduction
 from snap_financial_factors.deductions.child_support_payments_deduction import ChildSupportPaymentsDeduction
+from snap_financial_factors.deductions.standard_deduction import StandardDeduction
 from snap_financial_factors.input_data.input_data import InputData
 
 
@@ -59,16 +59,16 @@ class NetIncome:
         # Add up deductions:
 
         # Standard deduction
-        deductions = FetchDeductions(state_or_territory, household_size, deductions_data)
-        standard_deduction = deductions.standard_deduction()
-
-        standard_deduction_pdf_url = 'https://fns-prod.azureedge.net/sites/default/files/media/file/FY20-Maximum-Allotments-Deductions.pdf'
-        standard_deduction_explanation = (
-            "\nNext, we need to take into account deductions. " +
-            f"We start with a standard deduction of ${standard_deduction}. " +
-            f"<a class='why why-small' href='{standard_deduction_pdf_url}' target='_blank'>why?</a>"
+        standard_deduction_calculator = StandardDeduction(
+            state_or_territory=state_or_territory,
+            household_size=household_size,
+            deductions_data=deductions_data
         )
-        explanation.append(standard_deduction_explanation)
+        standard_deduction_calculation = standard_deduction_calculator.calculate()
+        standard_deduction = standard_deduction_calculation.result
+        standard_deduction_explanations = standard_deduction_calculation.explanation
+        for standard_deduction_explanation in standard_deduction_explanations:
+            explanation.append(standard_deduction_explanation)
 
         # Earned income deduction
         earned_income_deduction_calculator = EarnedIncomeDeduction(self.monthly_job_income)
@@ -113,7 +113,7 @@ class NetIncome:
                             child_support_payments_deduction)
 
         total_deductions_explanation = (
-            f"Next, we add all the deductions together: "
+            f"Next, we add all applicable deductions together: "
         )
         explanation.append(total_deductions_explanation)
         explanation.append('')

--- a/snap_financial_factors/calculations/net_income.py
+++ b/snap_financial_factors/calculations/net_income.py
@@ -37,7 +37,6 @@ class NetIncome:
         deductions_data = self.deductions_data
         monthly_job_income = self.monthly_job_income
         monthly_non_job_income = self.monthly_non_job_income
-        child_support_payments_deductible = self.child_support_payments_deductible
 
         explanation = []
         explanation_intro = (
@@ -110,7 +109,8 @@ class NetIncome:
         total_deductions = (standard_deduction +
                             earned_income_deduction +
                             dependent_care_deduction +
-                            medical_expenses_deduction)
+                            medical_expenses_deduction +
+                            child_support_payments_deduction)
 
         total_deductions_explanation = (
             f"Next, we add all the deductions together: "

--- a/snap_financial_factors/calculations/net_income.py
+++ b/snap_financial_factors/calculations/net_income.py
@@ -93,9 +93,12 @@ class NetIncome:
 
         # Construct math explanation for total deductions:
         total_deductions_math_explanation = ''
-        deduction_results_length = len(deduction_results)
-        for index, deduction_value in enumerate(deduction_results):
-            if index == (deduction_results_length - 1):
+        applicable_deductions = [
+            deduction for deduction in deduction_results if deduction > 0
+        ]
+        applicable_deductions_len = len(applicable_deductions)
+        for index, deduction_value in enumerate(applicable_deductions):
+            if index == (applicable_deductions_len - 1):
                 total_deductions_math_explanation += f"${deduction_value} = "
             else:
                 total_deductions_math_explanation += f"${deduction_value} + "

--- a/snap_financial_factors/deductions/child_support_payments_deduction.py
+++ b/snap_financial_factors/deductions/child_support_payments_deduction.py
@@ -7,15 +7,14 @@ class ChildSupportPaymentsDeduction:
     '''
 
     def __init__(self,
-                 child_support_payments_deductible: bool,
+                 child_support_payments_treatment: str,
                  court_ordered_child_support_payments: int) -> None:
-        self.child_support_payments_deductible = child_support_payments_deductible
+        self.child_support_payments_treatment = child_support_payments_treatment
         self.court_ordered_child_support_payments = court_ordered_child_support_payments
 
     def calculate(self) -> DeductionResult:
-        if self.child_support_payments_deductible is False:
+        if self.child_support_payments_treatment != 'DEDUCT':
             return DeductionResult(
-                is_applicable=False,
                 result=0,
                 explanation=[
                     'Court-ordered child support payments are not deductible in this state.'
@@ -24,7 +23,6 @@ class ChildSupportPaymentsDeduction:
 
         if self.court_ordered_child_support_payments == 0:
             return DeductionResult(
-                is_applicable=False,
                 result=0,
                 explanation=[
                     'This household does not make monthly court-ordered ' +
@@ -35,7 +33,6 @@ class ChildSupportPaymentsDeduction:
 
         return DeductionResult(
             result=(self.court_ordered_child_support_payments),
-            is_applicable=True,
             explanation=[
                 "Next, we deduct the monthly cost of court-ordered " +
                 f"child support payments: ${self.court_ordered_child_support_payments}."

--- a/snap_financial_factors/deductions/child_support_payments_deduction.py
+++ b/snap_financial_factors/deductions/child_support_payments_deduction.py
@@ -37,7 +37,7 @@ class ChildSupportPaymentsDeduction:
             result=(self.court_ordered_child_support_payments),
             is_applicable=True,
             explanation=[
-                "Next, we deduct the monthly cost of court-ordered: " +
+                "Next, we deduct the monthly cost of court-ordered " +
                 f"child support payments: ${self.court_ordered_child_support_payments}."
             ]
         )

--- a/snap_financial_factors/deductions/child_support_payments_deduction.py
+++ b/snap_financial_factors/deductions/child_support_payments_deduction.py
@@ -27,7 +27,9 @@ class ChildSupportPaymentsDeduction:
                 is_applicable=False,
                 result=0,
                 explanation=[
-                    'This household does not make monthly court-ordered child support payments.'
+                    'This household does not make monthly court-ordered ' +
+                    'child support payments, so the child-support payment ' +
+                    'deduction does not apply.'
                 ]
             )
 

--- a/snap_financial_factors/deductions/child_support_payments_deduction.py
+++ b/snap_financial_factors/deductions/child_support_payments_deduction.py
@@ -13,7 +13,7 @@ class ChildSupportPaymentsDeduction:
         self.court_ordered_child_support_payments = court_ordered_child_support_payments
 
     def calculate(self) -> DeductionResult:
-        if self.child_support_payments_deductible == False:
+        if self.child_support_payments_deductible is False:
             return DeductionResult(
                 is_applicable=False,
                 result=0,

--- a/snap_financial_factors/deductions/child_support_payments_deduction.py
+++ b/snap_financial_factors/deductions/child_support_payments_deduction.py
@@ -1,0 +1,41 @@
+from snap_financial_factors.deductions.deduction_result import DeductionResult
+
+
+class ChildSupportPaymentsDeduction:
+    '''
+    Calculates deduction for court-ordered (legally owed) child support payments.
+    '''
+
+    def __init__(self,
+                 child_support_payments_deductible: bool,
+                 court_ordered_child_support_payments: int) -> None:
+        self.child_support_payments_deductible = child_support_payments_deductible
+        self.court_ordered_child_support_payments = court_ordered_child_support_payments
+
+    def calculate(self) -> DeductionResult:
+        if self.child_support_payments_deductible == False:
+            return DeductionResult(
+                is_applicable=False,
+                result=0,
+                explanation=[
+                    'Court-ordered child support payments are not deductible in this state.'
+                ]
+            )
+
+        if self.court_ordered_child_support_payments == 0:
+            return DeductionResult(
+                is_applicable=False,
+                result=0,
+                explanation=[
+                    'This household does not make monthly court-ordered child support payments.'
+                ]
+            )
+
+        return DeductionResult(
+            result=(self.court_ordered_child_support_payments),
+            is_applicable=True,
+            explanation=[
+                "Next, we deduct the monthly cost of court-ordered: " +
+                f"child support payments: ${self.court_ordered_child_support_payments}."
+            ]
+        )

--- a/snap_financial_factors/deductions/deduction_result.py
+++ b/snap_financial_factors/deductions/deduction_result.py
@@ -6,7 +6,6 @@ class DeductionResult:
     Expresses the result of a deduction calculation.
     '''
 
-    def __init__(self, result: int, is_applicable: bool, explanation: List[str]) -> None:
+    def __init__(self, result: int, explanation: List[str]) -> None:
         self.result = result
-        self.is_applicable = is_applicable
         self.explanation = explanation

--- a/snap_financial_factors/deductions/dependent_care_deduction.py
+++ b/snap_financial_factors/deductions/dependent_care_deduction.py
@@ -16,6 +16,5 @@ class DependentCareDeduction:
 
         return DeductionResult(
             result=self.dependent_care_costs,
-            is_applicable=(self.dependent_care_costs > 0),
             explanation=explanation
         )

--- a/snap_financial_factors/deductions/earned_income_deduction.py
+++ b/snap_financial_factors/deductions/earned_income_deduction.py
@@ -25,6 +25,5 @@ class EarnedIncomeDeduction:
 
         return DeductionResult(
             result=earned_income_deduction,
-            is_applicable=(self.monthly_job_income > 0),
             explanation=explanation
         )

--- a/snap_financial_factors/deductions/medical_expenses_deduction.py
+++ b/snap_financial_factors/deductions/medical_expenses_deduction.py
@@ -26,7 +26,6 @@ class MedicalExpensesDeduction:
 
             return DeductionResult(
                 result=0,
-                is_applicable=False,
                 explanation=explanation
             )
 
@@ -37,7 +36,6 @@ class MedicalExpensesDeduction:
 
             return DeductionResult(
                 result=0,
-                is_applicable=False,
                 explanation=explanation
             )
 
@@ -48,7 +46,6 @@ class MedicalExpensesDeduction:
 
             return DeductionResult(
                 result=0,
-                is_applicable=False,
                 explanation=explanation
             )
 
@@ -65,6 +62,5 @@ class MedicalExpensesDeduction:
 
         return DeductionResult(
             result=medical_expenses_deduction,
-            is_applicable=True,
             explanation=explanation
         )

--- a/snap_financial_factors/deductions/standard_deduction.py
+++ b/snap_financial_factors/deductions/standard_deduction.py
@@ -1,0 +1,35 @@
+from typing import Dict
+from snap_financial_factors.deductions.deduction_result import DeductionResult
+from snap_financial_factors.program_data_api.fetch_deductions import FetchDeductions
+
+
+class StandardDeduction:
+    '''
+    Calculates standard deduction amount.
+    '''
+    def __init__(self,
+                 state_or_territory: str,
+                 household_size: int,
+                 deductions_data: Dict) -> None:
+        self.state_or_territory = state_or_territory
+        self.household_size = household_size
+        self.deductions_data = deductions_data
+
+    def calculate(self) -> DeductionResult:
+        deductions = FetchDeductions(self.state_or_territory,
+                                     self.household_size,
+                                     self.deductions_data)
+        standard_deduction = deductions.standard_deduction()
+
+        standard_deduction_pdf_url = 'https://fns-prod.azureedge.net/sites/default/files/media/file/FY20-Maximum-Allotments-Deductions.pdf'
+        explanation = [
+            "\nNext, we need to take into account deductions. " +
+            f"We start with a standard deduction of ${standard_deduction}. " +
+            f"<a class='why why-small' href='{standard_deduction_pdf_url}' target='_blank'>why?</a>"
+        ]
+
+        return DeductionResult(
+            result=standard_deduction,
+            is_applicable=True,
+            explanation=explanation
+        )

--- a/snap_financial_factors/deductions/standard_deduction.py
+++ b/snap_financial_factors/deductions/standard_deduction.py
@@ -30,6 +30,5 @@ class StandardDeduction:
 
         return DeductionResult(
             result=standard_deduction,
-            is_applicable=True,
             explanation=explanation
         )

--- a/snap_financial_factors/income/gross_income.py
+++ b/snap_financial_factors/income/gross_income.py
@@ -1,0 +1,67 @@
+from snap_financial_factors.input_data.input_data import InputData
+from snap_financial_factors.income.income_result import IncomeResult
+
+
+class GrossIncome:
+    '''
+    Returns the adjusted net income (income minus exclusions).
+    '''
+
+    def __init__(self, input_data: InputData, child_support_payments_treatment: str) -> None:
+        self.monthly_job_income = input_data.monthly_job_income
+        self.monthly_non_job_income = input_data.monthly_non_job_income
+        self.child_support_payments_treatment = child_support_payments_treatment
+        self.court_ordered_child_support_payments = input_data.court_ordered_child_support_payments
+
+    def child_support_payments_excluded(self) -> bool:
+        if self.child_support_payments_treatment != 'EXCLUDE':
+            return False
+
+        if self.court_ordered_child_support_payments == 0:
+            return False
+
+        return True
+
+    def calculate(self) -> IncomeResult:
+        child_support_payments_excluded = self.child_support_payments_excluded()
+
+        monthly_income = self.monthly_job_income + self.monthly_non_job_income
+
+        if child_support_payments_excluded:
+            return self.calculate_with_child_support_payments_excluded()
+        else:
+            return IncomeResult(
+                result=monthly_income,
+                explanation=[],
+                sort_order=0
+            )
+
+    def calculate_with_child_support_payments_excluded(self) -> IncomeResult:
+        monthly_income = self.monthly_job_income + self.monthly_non_job_income
+
+        explanation = []
+        child_support_payments_explanation = (
+            'In this state, court-ordered child support payments are ' +
+            'counted as a gross income exclusion. The gross income is ' +
+            'adjusted to exclude monthly court-ordered child support:'
+        )
+        explanation.append(child_support_payments_explanation)
+
+        monthly_income_minus_child_support = (
+            monthly_income - self.court_ordered_child_support_payments
+        )
+
+        child_support_payments_math = (
+            f"${monthly_income} - " +
+            f"${self.court_ordered_child_support_payments} = " +
+            f"${monthly_income_minus_child_support} adjusted gross income"
+        )
+        explanation.append(child_support_payments_math)
+
+        monthly_income = monthly_income_minus_child_support
+
+        return IncomeResult(
+            result=monthly_income,
+            explanation=explanation,
+            sort_order=0
+        )

--- a/snap_financial_factors/income/gross_income.py
+++ b/snap_financial_factors/income/gross_income.py
@@ -25,15 +25,30 @@ class GrossIncome:
     def calculate(self) -> IncomeResult:
         child_support_payments_excluded = self.child_support_payments_excluded()
 
-        monthly_income = self.monthly_job_income + self.monthly_non_job_income
-
         if child_support_payments_excluded:
             return self.calculate_with_child_support_payments_excluded()
         else:
+            explanation = []
+
+            gross_income_intro = [
+                'We find gross income by adding up monthly income from both ' +
+                'job and non-job sources.'
+            ]
+            explanation.append(gross_income_intro)
+
+            monthly_income = self.monthly_job_income + self.monthly_non_job_income
+
+            gross_income_math = (
+                f"${self.monthly_job_income} monthly job income + " +
+                f"${self.monthly_non_job_income} monthly non-job income = " +
+                f"<strong>${monthly_income} gross income</strong>"
+            )
+            explanation.append(gross_income_math)
+
             return IncomeResult(
                 name='Gross Income',
                 result=monthly_income,
-                explanation=[],
+                explanation=explanation,
                 sort_order=0
             )
 

--- a/snap_financial_factors/income/gross_income.py
+++ b/snap_financial_factors/income/gross_income.py
@@ -30,10 +30,10 @@ class GrossIncome:
         else:
             explanation = []
 
-            gross_income_intro = [
+            gross_income_intro = (
                 'We find gross income by adding up monthly income from both ' +
                 'job and non-job sources.'
-            ]
+            )
             explanation.append(gross_income_intro)
 
             monthly_income = self.monthly_job_income + self.monthly_non_job_income

--- a/snap_financial_factors/income/gross_income.py
+++ b/snap_financial_factors/income/gross_income.py
@@ -31,6 +31,7 @@ class GrossIncome:
             return self.calculate_with_child_support_payments_excluded()
         else:
             return IncomeResult(
+                name='Gross Income',
                 result=monthly_income,
                 explanation=[],
                 sort_order=0
@@ -61,6 +62,7 @@ class GrossIncome:
         monthly_income = monthly_income_minus_child_support
 
         return IncomeResult(
+            name='Gross Income',
             result=monthly_income,
             explanation=explanation,
             sort_order=0

--- a/snap_financial_factors/income/income_result.py
+++ b/snap_financial_factors/income/income_result.py
@@ -15,7 +15,3 @@ class IncomeResult:
         self.result = result
         self.explanation = explanation
         self.sort_order = sort_order
-        self.name_and_explanation = {
-            'name': name,
-            'explanation': explanation,
-        }

--- a/snap_financial_factors/income/income_result.py
+++ b/snap_financial_factors/income/income_result.py
@@ -4,6 +4,9 @@ from typing import List
 class IncomeResult:
     '''
     Expresses the result of an income calculation.
+
+    Duck types with TestResult and BenefitAmountResult across `name`,
+    `explanation`, and `sort_order`.
     '''
 
     def __init__(self,

--- a/snap_financial_factors/income/income_result.py
+++ b/snap_financial_factors/income/income_result.py
@@ -1,0 +1,12 @@
+from typing import List
+
+
+class IncomeResult:
+    '''
+    Expresses the result of an income calculation.
+    '''
+
+    def __init__(self, result: int, explanation: List[str], sort_order: int) -> None:
+        self.result = result
+        self.explanation = explanation
+        self.sort_order = sort_order

--- a/snap_financial_factors/income/income_result.py
+++ b/snap_financial_factors/income/income_result.py
@@ -6,7 +6,16 @@ class IncomeResult:
     Expresses the result of an income calculation.
     '''
 
-    def __init__(self, result: int, explanation: List[str], sort_order: int) -> None:
+    def __init__(self,
+                 name: str,
+                 result: int,
+                 explanation: List[str],
+                 sort_order: int) -> None:
+        self.name = name
         self.result = result
         self.explanation = explanation
         self.sort_order = sort_order
+        self.name_and_explanation = {
+            'name': name,
+            'explanation': explanation,
+        }

--- a/snap_financial_factors/income/net_income.py
+++ b/snap_financial_factors/income/net_income.py
@@ -15,21 +15,21 @@ class NetIncome:
 
     def __init__(self,
                  input_data: InputData,
+                 gross_income: int,
                  deductions_data: Dict,
                  child_support_payments_treatment: str) -> None:
         # Load user input data
         self.input_data = input_data
+        self.monthly_job_income = input_data.monthly_job_income
         self.state_or_territory = input_data.state_or_territory
         self.household_size = input_data.household_size
-        self.monthly_job_income = input_data.monthly_job_income
-        self.monthly_non_job_income = input_data.monthly_non_job_income
         self.dependent_care_costs = input_data.dependent_care_costs
         self.household_includes_elderly_or_disabled = input_data.household_includes_elderly_or_disabled
         self.medical_expenses_for_elderly_or_disabled = input_data.medical_expenses_for_elderly_or_disabled
         self.court_ordered_child_support_payments = input_data.court_ordered_child_support_payments
 
         self.deductions_data = deductions_data
-
+        self.gross_income = gross_income
         self.child_support_payments_treatment = child_support_payments_treatment
 
     def calculate(self):
@@ -42,12 +42,9 @@ class NetIncome:
         explanation.append(explanation_intro)
 
         # Add up income.
-        total_income = self.monthly_job_income + self.monthly_non_job_income
         income_explanation = (
             "Let's start with total household income. " +
-            f"This household reports monthly earned income of ${self.monthly_job_income} " +
-            f"and additional monthly income of ${self.monthly_non_job_income}, " +
-            f"for a total income of <strong>${total_income}.</strong>"
+            f"This household's gross income is ${self.gross_income}."
         )
         explanation.append(income_explanation)
 
@@ -111,14 +108,14 @@ class NetIncome:
         )
         explanation.append(total_deductions_summary)
 
-        net_income = total_income - total_deductions_value
+        net_income = self.gross_income - total_deductions_value
 
         # Adjusted net income can't be negative
         if 0 > net_income:
             net_income = 0
 
         calculation_explanation = (
-            f"Total income (<strong>${total_income}</strong>) minus " +
+            f"Gross income (<strong>${self.gross_income}</strong>) minus " +
             f"total deductions (<strong>${total_deductions_value}</strong>) " +
             f"equals net income: <strong>${net_income}.</strong>"
         )

--- a/snap_financial_factors/income/net_income.py
+++ b/snap_financial_factors/income/net_income.py
@@ -16,7 +16,7 @@ class NetIncome:
     def __init__(self,
                  input_data: InputData,
                  deductions_data: Dict,
-                 child_support_payments_treatment: str) -> IncomeResult:
+                 child_support_payments_treatment: str) -> None:
         # Load user input data
         self.input_data = input_data
         self.state_or_territory = input_data.state_or_territory

--- a/snap_financial_factors/income/net_income.py
+++ b/snap_financial_factors/income/net_income.py
@@ -5,6 +5,7 @@ from snap_financial_factors.deductions.medical_expenses_deduction import Medical
 from snap_financial_factors.deductions.child_support_payments_deduction import ChildSupportPaymentsDeduction
 from snap_financial_factors.deductions.standard_deduction import StandardDeduction
 from snap_financial_factors.input_data.input_data import InputData
+from snap_financial_factors.income.income_result import IncomeResult
 
 
 class NetIncome:
@@ -15,7 +16,7 @@ class NetIncome:
     def __init__(self,
                  input_data: InputData,
                  deductions_data: Dict,
-                 child_support_payments_deductible: bool):
+                 child_support_payments_treatment: str) -> IncomeResult:
         # Load user input data
         self.input_data = input_data
         self.state_or_territory = input_data.state_or_territory
@@ -29,7 +30,7 @@ class NetIncome:
 
         self.deductions_data = deductions_data
 
-        self.child_support_payments_deductible = child_support_payments_deductible
+        self.child_support_payments_treatment = child_support_payments_treatment
 
     def calculate(self):
         explanation = []
@@ -66,7 +67,7 @@ class NetIncome:
                 medical_expenses_for_elderly_or_disabled=self.medical_expenses_for_elderly_or_disabled
             ),
             ChildSupportPaymentsDeduction(
-                child_support_payments_deductible=self.child_support_payments_deductible,
+                child_support_payments_treatment=self.child_support_payments_treatment,
                 court_ordered_child_support_payments=self.court_ordered_child_support_payments,
             )
         ]
@@ -123,11 +124,8 @@ class NetIncome:
         )
         explanation.append(calculation_explanation)
 
-        return {
-            'result': net_income,
-            'reason': {
-                'test_name': 'Net Income',
-                'description': explanation,
-                'sort_order': 0,
-            }
-        }
+        return IncomeResult(
+            result=net_income,
+            explanation=explanation,
+            sort_order=1
+        )

--- a/snap_financial_factors/income/net_income.py
+++ b/snap_financial_factors/income/net_income.py
@@ -125,6 +125,7 @@ class NetIncome:
         explanation.append(calculation_explanation)
 
         return IncomeResult(
+            name='Net Income',
             result=net_income,
             explanation=explanation,
             sort_order=1

--- a/snap_financial_factors/input_data/input_data.py
+++ b/snap_financial_factors/input_data/input_data.py
@@ -4,6 +4,8 @@ from typing import Dict
 class InputData:
     '''
     Holds input data to API.
+
+    Any new input factors must be handled here and in the ParseInputData class.
     '''
 
     def __init__(self, input_data: Dict) -> None:

--- a/snap_financial_factors/input_data/input_data.py
+++ b/snap_financial_factors/input_data/input_data.py
@@ -15,3 +15,4 @@ class InputData:
         self.resources = input_data['resources']
         self.dependent_care_costs = input_data['dependent_care_costs']
         self.medical_expenses_for_elderly_or_disabled = input_data['medical_expenses_for_elderly_or_disabled']
+        self.court_ordered_child_support_payments = input_data['court_ordered_child_support_payments']

--- a/snap_financial_factors/input_data/parse_input_data.py
+++ b/snap_financial_factors/input_data/parse_input_data.py
@@ -21,23 +21,10 @@ class ParseInputData:
         input_data['monthly_non_job_income'] = int(input_data['monthly_non_job_income'])
         input_data['resources'] = int(input_data['resources'])
 
-        # Optional value. Set default; convert to int when value supplied:
-        if 'dependent_care_costs' in input_data:
-            if input_data['dependent_care_costs']:
-                input_data['dependent_care_costs'] = int(input_data['dependent_care_costs'])
-            else:
-                input_data['dependent_care_costs'] = 0
-        else:
-            input_data['dependent_care_costs'] = 0
-
-        # Optional value. Set default; convert to int when value supplied:
-        if 'medical_expenses_for_elderly_or_disabled' in input_data:
-            if input_data['medical_expenses_for_elderly_or_disabled']:
-                input_data['medical_expenses_for_elderly_or_disabled'] = int(input_data['medical_expenses_for_elderly_or_disabled'])
-            else:
-                input_data['medical_expenses_for_elderly_or_disabled'] = 0
-        else:
-            input_data['medical_expenses_for_elderly_or_disabled'] = 0
+        # Parse optional integer input data:
+        input_data['dependent_care_costs'] = self.parse_optional_integer_input('dependent_care_costs')
+        input_data['medical_expenses_for_elderly_or_disabled'] = self.parse_optional_integer_input('medical_expenses_for_elderly_or_disabled')
+        input_data['court_ordered_child_support_payments'] = self.parse_optional_integer_input('court_ordered_child_support_payments')
 
         # Parse booleans sent in as strings:
         includes_elderly_or_disabled = input_data['household_includes_elderly_or_disabled']
@@ -47,3 +34,12 @@ class ParseInputData:
             )
 
         return InputData(input_data)
+
+    def parse_optional_integer_input(self, input_key: str) -> None:
+        if input_key in self.input_data:         # Check if the key exists in the dict
+            if self.input_data[input_key]:       # Parse as int if value is int or present string
+                return int(self.input_data[input_key])
+            else:                                # Set to zero if value is null or empty string
+                return 0
+        else:                                    # Set to zero if value does not exist in dict
+            return 0

--- a/snap_financial_factors/input_data/parse_input_data.py
+++ b/snap_financial_factors/input_data/parse_input_data.py
@@ -37,7 +37,7 @@ class ParseInputData:
 
         return InputData(input_data)
 
-    def parse_optional_integer_input(self, input_key: str) -> None:
+    def parse_optional_integer_input(self, input_key: str) -> int:
         if input_key in self.input_data:         # Check if the key exists in the dict
             if self.input_data[input_key]:       # Parse as int if value is int or present string
                 return int(self.input_data[input_key])

--- a/snap_financial_factors/input_data/parse_input_data.py
+++ b/snap_financial_factors/input_data/parse_input_data.py
@@ -7,6 +7,8 @@ class ParseInputData:
     Cleans up input data sent to API:
     * Converts strings to integers as needed
     * Sets defaults
+
+    Any new input factors must be handled here and in the InputData class.
     '''
 
     def __init__(self, input_data: Dict) -> None:

--- a/snap_financial_factors/tests/asset_test.py
+++ b/snap_financial_factors/tests/asset_test.py
@@ -41,7 +41,7 @@ class AssetTest:
             description.append('Assets: {}.'.format(self.resources))
             description.append('Meets eligibility test? {}.'.format(below_resource_limit))
         else:
-            description = 'This state does not have a resource limit.'
+            description = ['This state does not have a resource limit.']
             below_resource_limit = True
 
         return TestResult(

--- a/snap_financial_factors/tests/asset_test.py
+++ b/snap_financial_factors/tests/asset_test.py
@@ -1,4 +1,5 @@
 from snap_financial_factors.input_data.input_data import InputData
+from snap_financial_factors.tests.test_result import TestResult
 
 
 class AssetTest:
@@ -13,16 +14,16 @@ class AssetTest:
         self.resource_limit_elderly_or_disabled = resource_limit_elderly_or_disabled
         self.resource_limit_non_elderly_or_disabled = resource_limit_non_elderly_or_disabled
 
-    def calculate(self):
+    def calculate(self) -> TestResult:
         if (self.resource_limit_elderly_or_disabled is None) and (self.resource_limit_non_elderly_or_disabled is None):
-            return {
-                'result': True,
-                'reason': {
-                    'test_name': 'Asset Test',
-                    'test_passed?': True,
-                    'description': [f"{self.state_or_territory} does not have an asset test for SNAP eligibility."]
-                }
-            }
+            return TestResult(
+                test_name='Asset Test',
+                result=True,
+                explanation=[
+                    f"{self.state_or_territory} does not have an asset test for SNAP eligibility."
+                ],
+                sort_order=4,
+            )
 
         has_resource_limit = (self.household_includes_elderly_or_disabled or
                               self.resource_limit_non_elderly_or_disabled)
@@ -43,12 +44,9 @@ class AssetTest:
             description = 'This state does not have a resource limit.'
             below_resource_limit = True
 
-        return {
-            'result': below_resource_limit,
-            'reason': {
-                'test_name': 'Asset Test',
-                'test_passed?': below_resource_limit,
-                'description': description,
-                'sort_order': 3,
-            }
-        }
+        return TestResult(
+            test_name='Asset Test',
+            result=below_resource_limit,
+            explanation=description,
+            sort_order=4,
+        )

--- a/snap_financial_factors/tests/asset_test.py
+++ b/snap_financial_factors/tests/asset_test.py
@@ -17,7 +17,7 @@ class AssetTest:
     def calculate(self) -> TestResult:
         if (self.resource_limit_elderly_or_disabled is None) and (self.resource_limit_non_elderly_or_disabled is None):
             return TestResult(
-                test_name='Asset Test',
+                name='Asset Test',
                 result=True,
                 explanation=[
                     f"{self.state_or_territory} does not have an asset test for SNAP eligibility."
@@ -45,7 +45,7 @@ class AssetTest:
             below_resource_limit = True
 
         return TestResult(
-            test_name='Asset Test',
+            name='Asset Test',
             result=below_resource_limit,
             explanation=description,
             sort_order=4,

--- a/snap_financial_factors/tests/gross_income_test.py
+++ b/snap_financial_factors/tests/gross_income_test.py
@@ -21,7 +21,7 @@ class GrossIncomeTest:
     def calculate(self) -> TestResult:
         if self.household_includes_elderly_or_disabled:
             return TestResult(
-                test_name='Gross Income Test',
+                name='Gross Income Test',
                 result=True,
                 explanation=[
                     'Households with an elderly or disabled member do not need to meet the gross income test.'
@@ -58,7 +58,7 @@ class GrossIncomeTest:
         explanation.append(result_explanation)
 
         return TestResult(
-            test_name='Gross Income Test',
+            name='Gross Income Test',
             result=below_gross_income_limit,
             explanation=explanation,
             sort_order=2,

--- a/snap_financial_factors/tests/gross_income_test.py
+++ b/snap_financial_factors/tests/gross_income_test.py
@@ -2,7 +2,11 @@ from snap_financial_factors.input_data.input_data import InputData
 
 
 class GrossIncomeTest:
-    def __init__(self, input_data: InputData, income_limits, gross_income_limit_factor):
+    def __init__(self,
+                 input_data: InputData,
+                 income_limits,
+                 gross_income_limit_factor,
+                 child_support_payments_deductible: bool) -> None:
         # Load user input data
         self.input_data = input_data
         self.state_or_territory = input_data.state_or_territory
@@ -14,6 +18,11 @@ class GrossIncomeTest:
 
         self.income_limits = income_limits
         self.gross_income_limit_factor = gross_income_limit_factor
+
+        # If child support payments are not deductible, they are counted as
+        # exclusions from gross income.
+        self.child_support_payments_deductible = child_support_payments_deductible
+        self.court_ordered_child_support_payments = input_data.court_ordered_child_support_payments
 
     def calculate(self):
         if self.household_includes_elderly_or_disabled:
@@ -40,7 +49,33 @@ class GrossIncomeTest:
         )
         explanation.append(gross_monthly_income_limit_explanation)
 
+        # Calculate monthly income:
         monthly_income = self.monthly_job_income + self.monthly_non_job_income
+
+        # Exclude child support payments depending on state option:
+        if (self.court_ordered_child_support_payments > 0
+                and not self.child_support_payments_deductible):
+            child_support_payments_explanation = (
+                'In this state, court-ordered child support payments are ' +
+                'counted as a gross income exclusion. The gross income is ' +
+                'adjusted to exclude monthly court-ordered child support:'
+            )
+            explanation.append(child_support_payments_explanation)
+
+            monthly_income_minus_child_support = (
+                monthly_income - self.court_ordered_child_support_payments
+            )
+
+            child_support_payments_math = (
+                f"${monthly_income} - " +
+                f"${self.court_ordered_child_support_payments} = " +
+                f"${monthly_income_minus_child_support} adjusted gross income"
+            )
+            explanation.append(child_support_payments_math)
+
+            monthly_income = monthly_income_minus_child_support
+
+        # Result:
         below_gross_income_limit = (gross_monthly_income_limit > monthly_income)
 
         result_to_words = {

--- a/snap_financial_factors/tests/gross_income_test.py
+++ b/snap_financial_factors/tests/gross_income_test.py
@@ -4,25 +4,18 @@ from snap_financial_factors.input_data.input_data import InputData
 class GrossIncomeTest:
     def __init__(self,
                  input_data: InputData,
+                 gross_income: bool,
                  income_limits,
-                 gross_income_limit_factor,
-                 child_support_payments_deductible: bool) -> None:
+                 gross_income_limit_factor) -> None:
         # Load user input data
         self.input_data = input_data
         self.state_or_territory = input_data.state_or_territory
-        self.monthly_job_income = input_data.monthly_job_income
-        self.monthly_non_job_income = input_data.monthly_non_job_income
         self.household_size = input_data.household_size
         self.household_includes_elderly_or_disabled = input_data.household_includes_elderly_or_disabled
         self.resources = input_data.resources
-
+        self.gross_income = gross_income
         self.income_limits = income_limits
         self.gross_income_limit_factor = gross_income_limit_factor
-
-        # If child support payments are not deductible, they are counted as
-        # exclusions from gross income.
-        self.child_support_payments_deductible = child_support_payments_deductible
-        self.court_ordered_child_support_payments = input_data.court_ordered_child_support_payments
 
     def calculate(self):
         if self.household_includes_elderly_or_disabled:
@@ -49,34 +42,8 @@ class GrossIncomeTest:
         )
         explanation.append(gross_monthly_income_limit_explanation)
 
-        # Calculate monthly income:
-        monthly_income = self.monthly_job_income + self.monthly_non_job_income
-
-        # Exclude child support payments depending on state option:
-        if (self.court_ordered_child_support_payments > 0
-                and not self.child_support_payments_deductible):
-            child_support_payments_explanation = (
-                'In this state, court-ordered child support payments are ' +
-                'counted as a gross income exclusion. The gross income is ' +
-                'adjusted to exclude monthly court-ordered child support:'
-            )
-            explanation.append(child_support_payments_explanation)
-
-            monthly_income_minus_child_support = (
-                monthly_income - self.court_ordered_child_support_payments
-            )
-
-            child_support_payments_math = (
-                f"${monthly_income} - " +
-                f"${self.court_ordered_child_support_payments} = " +
-                f"${monthly_income_minus_child_support} adjusted gross income"
-            )
-            explanation.append(child_support_payments_math)
-
-            monthly_income = monthly_income_minus_child_support
-
         # Result:
-        below_gross_income_limit = (gross_monthly_income_limit > monthly_income)
+        below_gross_income_limit = (gross_monthly_income_limit > self.gross_income)
 
         result_to_words = {
             True: 'passes',
@@ -84,7 +51,7 @@ class GrossIncomeTest:
         }
         result_in_words = result_to_words[below_gross_income_limit]
         result_explanation = (
-            f"Since the household total income is ${monthly_income}, " +
+            f"Since the household gross income is ${self.gross_income}, " +
             f"this household <strong>{result_in_words}</strong> the gross income test."
         )
         explanation.append(result_explanation)

--- a/snap_financial_factors/tests/gross_income_test.py
+++ b/snap_financial_factors/tests/gross_income_test.py
@@ -1,4 +1,5 @@
 from snap_financial_factors.input_data.input_data import InputData
+from snap_financial_factors.tests.test_result import TestResult
 
 
 class GrossIncomeTest:
@@ -17,16 +18,16 @@ class GrossIncomeTest:
         self.income_limits = income_limits
         self.gross_income_limit_factor = gross_income_limit_factor
 
-    def calculate(self):
+    def calculate(self) -> TestResult:
         if self.household_includes_elderly_or_disabled:
-            return {
-                'result': True,
-                'reason': {
-                    'test_name': 'Gross Income Test',
-                    'test_passed?': True,
-                    'description': ['Households with an elderly or disabled member do not need to meet the gross income test.']
-                }
-            }
+            return TestResult(
+                test_name='Gross Income Test',
+                result=True,
+                explanation=[
+                    'Households with an elderly or disabled member do not need to meet the gross income test.'
+                ],
+                sort_order=2,
+            )
 
         # The gross income limited is calculated as a percentage of the net
         # income limit, which is based on the federal poverty level.
@@ -56,12 +57,9 @@ class GrossIncomeTest:
         )
         explanation.append(result_explanation)
 
-        return {
-            'result': below_gross_income_limit,
-            'reason': {
-                'test_name': 'Gross Income Test',
-                'test_passed?': below_gross_income_limit,
-                'description': explanation,
-                'sort_order': 2,
-            }
-        }
+        return TestResult(
+            test_name='Gross Income Test',
+            result=below_gross_income_limit,
+            explanation=explanation,
+            sort_order=2,
+        )

--- a/snap_financial_factors/tests/net_income_test.py
+++ b/snap_financial_factors/tests/net_income_test.py
@@ -41,7 +41,7 @@ class NetIncomeTest:
         explanation.append(result_explanation)
 
         return TestResult(
-            test_name='Net Income Test',
+            name='Net Income Test',
             result=below_net_income_limit,
             explanation=explanation,
             sort_order=3,

--- a/snap_financial_factors/tests/net_income_test.py
+++ b/snap_financial_factors/tests/net_income_test.py
@@ -1,3 +1,6 @@
+from snap_financial_factors.tests.test_result import TestResult
+
+
 class NetIncomeTest:
     '''
     Evaluates net income against the appropriate net income threshold.
@@ -7,7 +10,7 @@ class NetIncomeTest:
         self.net_income = net_income
         self.income_limits = income_limits
 
-    def calculate(self):
+    def calculate(self) -> TestResult:
         net_income = self.net_income
         net_monthly_income_limit = self.income_limits.net_monthly_income_limit()
         below_net_income_limit = net_monthly_income_limit > net_income
@@ -37,12 +40,9 @@ class NetIncomeTest:
         )
         explanation.append(result_explanation)
 
-        return {
-            'result': below_net_income_limit,
-            'reason': {
-                'test_name': 'Net Income Test',
-                'test_passed?': below_net_income_limit,
-                'description': explanation,
-                'sort_order': 1
-            }
-        }
+        return TestResult(
+            test_name='Net Income Test',
+            result=below_net_income_limit,
+            explanation=explanation,
+            sort_order=3,
+        )

--- a/snap_financial_factors/tests/test_result.py
+++ b/snap_financial_factors/tests/test_result.py
@@ -16,3 +16,7 @@ class TestResult:
         self.result = result
         self.explanation = explanation
         self.sort_order = sort_order
+        self.name_and_explanation = {
+            'name': test_name,
+            'explanation': explanation,
+        }

--- a/snap_financial_factors/tests/test_result.py
+++ b/snap_financial_factors/tests/test_result.py
@@ -1,0 +1,18 @@
+from typing import List
+
+
+class TestResult:
+    '''
+    Expresses the result of a SNAP eligibility test.
+    '''
+
+    def __init__(self,
+                 test_name: str,
+                 result: bool,
+                 explanation: List[str],
+                 sort_order: int) -> None:
+
+        self.test_name = test_name
+        self.result = result
+        self.explanation = explanation
+        self.sort_order = sort_order

--- a/snap_financial_factors/tests/test_result.py
+++ b/snap_financial_factors/tests/test_result.py
@@ -4,6 +4,9 @@ from typing import List
 class TestResult:
     '''
     Expresses the result of a SNAP eligibility test.
+
+    Duck types with IncomeResult and BenefitAmountResult across `name`,
+    `explanation`, and `sort_order`.
     '''
 
     def __init__(self,

--- a/snap_financial_factors/tests/test_result.py
+++ b/snap_financial_factors/tests/test_result.py
@@ -16,7 +16,3 @@ class TestResult:
         self.result = result
         self.explanation = explanation
         self.sort_order = sort_order
-        self.name_and_explanation = {
-            'name': test_name,
-            'explanation': explanation,
-        }

--- a/snap_financial_factors/tests/test_result.py
+++ b/snap_financial_factors/tests/test_result.py
@@ -7,12 +7,12 @@ class TestResult:
     '''
 
     def __init__(self,
-                 test_name: str,
+                 name: str,
                  result: bool,
                  explanation: List[str],
                  sort_order: int) -> None:
 
-        self.test_name = test_name
+        self.name = name
         self.result = result
         self.explanation = explanation
         self.sort_order = sort_order

--- a/templates/prescreener.html
+++ b/templates/prescreener.html
@@ -156,6 +156,12 @@
                        name="medical_expenses_for_elderly_or_disabled"
                        class="usa-input" />
               </div>
+              <label class="usa-label" for="court_ordered_child_support_payments">
+                Monthly court-ordered child support payments:
+              </label>
+              <input id="court_ordered_child_support_payments"
+                     name="court_ordered_child_support_payments"
+                     class="usa-input" />
               <input id="prescreener-form-submit"
                      class="usa-button"
                      type="submit"

--- a/templates/prescreener.html
+++ b/templates/prescreener.html
@@ -222,11 +222,16 @@
 
           html += '<div id="reasons" class="hidden">';
 
-          var names_and_explanations = response.names_and_explanations;
-          for (var i = 0; i < names_and_explanations.length; i++) {
-              var name_and_explanation = names_and_explanations[i];
-              name = name_and_explanation.name
-              explanation = name_and_explanation.explanation
+          var eligibility_factors = response.eligibility_factors;
+          eligibility_factors.sort(function(a, b) {
+              return a.sort_order - b.sort_order;
+          });
+
+          for (var i = 0; i < eligibility_factors.length; i++) {
+              var eligibility_factor = eligibility_factors[i];
+              test_name = eligibility_factor.test_name
+              explanation = eligibility_factor.explanation
+
               html += ('<h3>' + name + ':</h3>')
 
               html += '<div>';

--- a/templates/prescreener.html
+++ b/templates/prescreener.html
@@ -222,15 +222,17 @@
 
           html += '<div id="reasons" class="hidden">';
 
-          var reasons = response.reasons;
-          for (var i = 0; i < reasons.length; i++) {
-              var reason = reasons[i];
-              html += ('<h3>' + reason.test_name + ':</h3>')
+          var names_and_explanations = response.names_and_explanations;
+          for (var i = 0; i < names_and_explanations.length; i++) {
+              var name_and_explanation = names_and_explanations[i];
+              name = name_and_explanation.name
+              explanation = name_and_explanation.explanation
+              html += ('<h3>' + name + ':</h3>')
 
               html += '<div>';
-              for (var j = 0; j < reason.length; j++) {
-                  var description = reason[j];
-                  html += ('<p>' + description + '</p>')
+              for (var j = 0; j < explanation.length; j++) {
+                  var explanation_graph = explanation[j];
+                  html += ('<p>' + explanation_graph + '</p>')
               }
               html += '</div>';
           }

--- a/templates/prescreener.html
+++ b/templates/prescreener.html
@@ -228,8 +228,8 @@
               html += ('<h3>' + reason.test_name + ':</h3>')
 
               html += '<div>';
-              for (var j = 0; j < reason.description.length; j++) {
-                  var description = reason.description[j];
+              for (var j = 0; j < reason.length; j++) {
+                  var description = reason[j];
                   html += ('<p>' + description + '</p>')
               }
               html += '</div>';

--- a/templates/prescreener.html
+++ b/templates/prescreener.html
@@ -227,9 +227,11 @@
               return a.sort_order - b.sort_order;
           });
 
+          console.log('eligibility_factors', eligibility_factors)
+
           for (var i = 0; i < eligibility_factors.length; i++) {
               var eligibility_factor = eligibility_factors[i];
-              test_name = eligibility_factor.test_name
+              name = eligibility_factor.name
               explanation = eligibility_factor.explanation
 
               html += ('<h3>' + name + ':</h3>')


### PR DESCRIPTION
# Goal

Model the child support payment deduction. 

From the FNS SNAP FAQ:

> What deductions are allowed in SNAP?
>
> _In some states, legally owed child support payments._

# The reg

> Optional child support deduction. At its option, the State agency may provide a deduction, rather than the income exclusion provided under paragraph (c)(17) of this section, for legally obligated child support payments paid by a household member to or for a nonhousehold member, including payments made to a third party on behalf of the nonhousehold member (vendor payments) and amounts paid toward child support arrearages. Alimony payments made to or for a nonhousehold member shall not be included in the child support deduction. A State agency that chooses to provide a child support deduction rather than an exclusion in accordance with this paragraph (d)(5) must specify in its State plan of operation that it has chosen to provide the deduction rather than the exclusion.

The reference to paragraph (c)(17) refers to exclusions:

> (c) Income exclusions. Only the following items shall be excluded from household income and no other income shall be excluded...

# The FNS data

Most recent State Options report I can find is 2018: see [2018 State Options Report](https://fns-prod.azureedge.net/sites/default/files/snap/14-State-Options.pdf), page 24.

# Other sources 

+ [MassLegalHelp article from 2017, "What income is not counted?"](https://www.masslegalhelp.org/income-benefits/food-stamps/advocacy-guide/part3/q69-income-not-counted) — Describes court-ordered child support payments as an income exclusion — but the 2018 State Options report describes MA as an income-deduction state. 
+ [Illinois Legal Aid Online article from 2017](https://www.illinoislegalaid.org/legal-information/helping-clients-snap-benefits) — Describes court-ordered child support payments as an income deduction — but the 2018 State Options report describes IL as an income-exclusion state. 
+ [CalFresh Handbook from the County of Santa Clara, CA, page 25](https://www.sccgov.org/ssa/foods/fschap19.pdf) — Says: "Legally obligated child support payments (including arrearages) that a household member pays to or for an individual living outside of the household are excluded as income by allowing them as a deduction. The child support exclusion/deduction is first deducted from the unearned income and any remainder is deducted from the earned income, with the 20% earned income deduction taken prior to the child support exclusion." — Doesn't seem to distinguish between exclusion and deduction and even uses "exclusion/deduction" as a concept.
+ [LSNC (Legal Services of Northern California) Guide to CalFresh Benefits, "Child support payments made by a household member to someone not in the household"](http://calfresh.guide/child-support-payments-made-by-a-household-member-to-someone-not-in-the-household/) — Says: "The SNAP program treats child support payments a household member is legally obligated to pay to a non-household member as an income exclusion, or at state option, as a deduction. [7 C.F.R. § 273.9(c)(17), 273.9(d)(5), 273.10(d)(8).] California has determined that they will deduct these payments from the income." However, the 2018 State Options report lists CA as an income-exclusion state.

# Questions 

+ The 2018 State Options Report seems to have different information from what I can find online about SNAP implementation in IL, MA, and CA. Why is that and what might I be missing?
+ When will the State Options Report for 2019 be published? What about for 2020?

A call with our partner at FNS helped clear up some of these questions — the State Options data is out-of-date and less accurate than we might like. But we'll model the state differences out, and we can always adjust state options data as we learn more. 

# Tech notes

+ This PR also introduces a refactor to how deductions are summed and explained within the `NetIncome` class; it uses duck typing to eliminate redundant code over each deduction calculation.
+ It also introduces a great deal of type-checking. 