### PR TITLE
Cache Python dependencies between CircleCI builds; small README update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,5 +38,6 @@ jobs:
           command: make test
 
       - save_cache:
-          path: ./.venv
+          paths:
+            - ./.venv
           key: pipenv-packages-{{ checksum "Pipfile.lock" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,9 @@ jobs:
     steps:
       - checkout
 
+      - restore_cache:
+          key: pipenv-packages-{{ checksum "Pipfile.lock" }}
+
       - run:
           name: Install Pipenv
           command: sudo pip install pipenv
@@ -33,3 +36,7 @@ jobs:
       - run:
           name: Feature tests
           command: make test
+
+      - save_cache:
+          path: ./.venv
+          key: pipenv-packages-{{ checksum "Pipfile.lock" }}

--- a/README.md
+++ b/README.md
@@ -43,7 +43,9 @@ Please reach out via [email](mailto:eligibility-apis-initiative@gsa.gov) if you 
 ```sh
 # IL, 1 person, no income or savings:
 
-curl -X POST -H "Content-Type: application/json" \
+curl -X POST \
+  -H "Content-Type: application/json" \
+  -u username:password \
   -d @./sample_input_data/il-1-person-no-income-or-savings.json \
   http://127.0.0.1:8000/calculate
 ```

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Please reach out via [email](mailto:eligibility-apis-initiative@gsa.gov) if you 
 
 curl -X POST -H "Content-Type: application/json" \
   -d @./sample_input_data/il-1-person-no-income-or-savings.json \
-  http://127.0.0.1:5000/calculate
+  http://127.0.0.1:8000/calculate
 ```
 
 # Modeling notes


### PR DESCRIPTION
# Notes 

+ CircleCI job run time down to 42 seconds from 2 or 3 minutes
+ ... also add minor documentation fixups just as a good excuse to kick the CircleCI tires a couple of times and see if the caching is working.