### PR TITLE
Move app name variable outside of Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,4 +42,5 @@ deploy-cf:
 logs: logs-cf
 
 logs-cf:
-	cf logs snap-prototype-financial-factors
+	./set_app_name.sh
+	cf logs ${APP_NAME}

--- a/set_app_name.sh
+++ b/set_app_name.sh
@@ -1,0 +1,1 @@
+export APP_NAME="snap-prototype-financial-factors"


### PR DESCRIPTION
# Notes 

+ Feels cleaner; Makefile should know as little about the state/config of the app as possible
+ Would be ideal to centralize changing the $APP_NAME in only one (or worst case, two) places