### PR TITLE
Add SNAP emergency allotments to model

### DIFF
--- a/features/vt.feature
+++ b/features/vt.feature
@@ -13,7 +13,8 @@ Feature: Testing SNAP Financial Factors Web API for VT
 
   Scenario: Household that would (just barely) fail the Gross Income test if
             they lived in IL (165% FPL), passes Gross and Net Income Test,
-            is overall eligible
+            is overall eligible, and receives max allotment because of
+            VT emergency SNAP allotment waiver
     Given the household is in VT
     And a 3-person household
     And the household does not include an elderly or disabled member
@@ -24,4 +25,4 @@ Feature: Testing SNAP Financial Factors Web API for VT
     And the household has rent or mortgage costs of $2000 monthly
     When we run the benefit estimator...
       Then we find the family is likely eligible
-      And we find the estimated benefit is $100 per month
+      And we find the estimated benefit is $509 per month

--- a/program_data/state_options.yaml
+++ b/program_data/state_options.yaml
@@ -22,9 +22,14 @@
 #
 # See the standard_utility_allowances folder and associated README for more
 # information, context, and parsing scripts.
+#
+# "Most States Are Easing SNAP Participation Rules; Many Have Opted to Provide Added Benefits", Center on Budget and Policy Priorities:
+#
+# https://www.cbpp.org/research/food-assistance/most-states-are-easing-snap-participation-rules-many-have-opted-to-provide
 
 CA:
     2020:
+        emergency_allotment: True  # As of 4/1/2020
         uses_bbce: True
         gross_income_limit_factor: 2
         resource_limit_elderly_or_disabled: NULL
@@ -35,6 +40,7 @@ CA:
 
 ID:
     2020:
+        emergency_allotment: False  # As of 4/1/2020
         uses_bbce: False
         gross_income_limit_factor: 1.3
         resource_limit_elderly_or_disabled: 5000
@@ -45,6 +51,7 @@ ID:
 
 IL:
     2020:
+        emergency_allotment: False  # As of 4/1/2020
         uses_bbce: True
         gross_income_limit_factor: 1.65
         resource_limit_elderly_or_disabled: NULL
@@ -69,6 +76,7 @@ IL:
 
 MA:
     2020:
+        emergency_allotment: True  # As of 4/1/2020
         uses_bbce: True
         gross_income_limit_factor: 2
         resource_limit_elderly_or_disabled: NULL
@@ -79,6 +87,7 @@ MA:
 
 MI:
     2020:
+        emergency_allotment: True  # As of 4/1/2020
         uses_bbce: True
         gross_income_limit_factor: 2
         resource_limit_elderly_or_disabled: 15000 # NOTE: Double-check this across households with/without elderly or disabled members.
@@ -99,6 +108,7 @@ MI:
 
 MN:
     2020:
+        emergency_allotment: False  # As of 4/1/2020
         uses_bbce: True
         gross_income_limit_factor: 1.65
         resource_limit_elderly_or_disabled: NULL
@@ -119,6 +129,7 @@ MN:
 
 UT:
     2020:
+        emergency_allotment: False  # As of 4/1/2020
         uses_bbce: False
         child_support_payments_treatment: DEDUCT  # According to USDA State Options Report. Options as of October 1, 2017.
         website: https://jobs.utah.gov/assistance/index.html
@@ -126,6 +137,7 @@ UT:
 
 VT:
     2020:
+        emergency_allotment: True  # As of 4/1/2020
         uses_bbce: True
         gross_income_limit_factor: 1.85
         resource_limit_elderly_or_disabled: NULL

--- a/program_data/state_options.yaml
+++ b/program_data/state_options.yaml
@@ -23,6 +23,10 @@
 # See the standard_utility_allowances folder and associated README for more
 # information, context, and parsing scripts.
 #
+# "SNAP Emergency Allotments to Current SNAP Households", USDA
+#
+# https://www.fns.usda.gov/disaster/pandemic/snap-emergency-allotments
+#
 # "Most States Are Easing SNAP Participation Rules; Many Have Opted to Provide Added Benefits", Center on Budget and Policy Priorities:
 #
 # https://www.cbpp.org/research/food-assistance/most-states-are-easing-snap-participation-rules-many-have-opted-to-provide

--- a/snap_financial_factors/benefit_estimate.py
+++ b/snap_financial_factors/benefit_estimate.py
@@ -46,7 +46,9 @@ class BenefitEstimate:
         eligibility_factors = eligibility_calculation['eligibility_factors']
         net_income = eligibility_calculation['net_income']
 
-        estimated_benefit = self.__estimated_monthly_benefit(is_eligible, net_income)
+        emergency_allotment = self.state_options_data[self.state_or_territory][2020]['emergency_allotment']
+
+        estimated_benefit = self.__estimated_monthly_benefit(is_eligible, net_income, emergency_allotment)
         estimated_benefit_amount = estimated_benefit.amount
         eligibility_factors.append(estimated_benefit.__dict__)
 
@@ -182,7 +184,8 @@ class BenefitEstimate:
 
     def __estimated_monthly_benefit(self,
                                     is_eligible: bool,
-                                    net_income: int) -> BenefitAmountResult:
+                                    net_income: int,
+                                    emergency_allotment: bool) -> BenefitAmountResult:
         """
         Returns estimate of monthly benefit, plus reasons behind its decision.
 
@@ -194,6 +197,7 @@ class BenefitEstimate:
                                                 self.max_allotments,
                                                 self.min_allotments,
                                                 is_eligible,
-                                                net_income)
+                                                net_income,
+                                                emergency_allotment)
 
         return amount_estimate.calculate()

--- a/snap_financial_factors/calculations/benefit_amount_estimate.py
+++ b/snap_financial_factors/calculations/benefit_amount_estimate.py
@@ -46,8 +46,10 @@ class BenefitAmountEstimate:
                                            self.household_size,
                                            self.max_allotments).calculate()
 
+        max_allotment_pdf_url = 'https://fns-prod.azureedge.net/sites/default/files/media/file/FY20-Maximum-Allotments-Deductions.pdf'
         max_allotment_explanation = (
-            f"In this case, the estimated benefit amount is ${max_allotment}."
+            f"In this case, the estimated benefit amount is ${max_allotment}. " +
+            f"<a class='why why-small' href='{max_allotment_pdf_url}' target='_blank'>why?</a>"
         )
         explanation.append(max_allotment_explanation)
 

--- a/snap_financial_factors/calculations/benefit_amount_estimate.py
+++ b/snap_financial_factors/calculations/benefit_amount_estimate.py
@@ -10,13 +10,15 @@ class BenefitAmountEstimate:
                  max_allotments,
                  min_allotments,
                  is_eligible,
-                 net_income):
+                 net_income,
+                 emergency_allotment: bool):
         self.state_or_territory = state_or_territory
         self.household_size = household_size
         self.max_allotments = max_allotments
         self.min_allotments = min_allotments
         self.is_eligible = is_eligible
         self.net_income = net_income
+        self.emergency_allotment = emergency_allotment
 
     def calculate(self):
         if not self.is_eligible:
@@ -27,6 +29,36 @@ class BenefitAmountEstimate:
                 sort_order=5
             )
 
+        if self.emergency_allotment:
+            return self.calculate_with_emergency_allotment()
+        else:
+            return self.calculate_without_emergency_allotment()
+
+    def calculate_with_emergency_allotment(self):
+        explanation_intro = (
+            'Because this state is offering an emergency SNAP benefit amount in response ' +
+            'to the current crisis, a household may receive the maximum monthly ' +
+            'benefit amount for their household size.'
+        )
+        explanation = [explanation_intro]
+
+        max_allotment = FetchMaxAllotments(self.state_or_territory,
+                                           self.household_size,
+                                           self.max_allotments).calculate()
+
+        max_allotment_explanation = (
+            f"In this case, the estimated benefit amount is ${max_allotment}."
+        )
+        explanation.append(max_allotment_explanation)
+
+        return BenefitAmountResult(
+            name='Estimated Benefit Calculation',
+            amount=max_allotment,
+            explanation=explanation,
+            sort_order=5
+        )
+
+    def calculate_without_emergency_allotment(self):
         explanation_intro = (
             'To determine the estimated amount of SNAP benefit, we start ' +
             'with the maximum allotment and then subtract 30% of net income ' +


### PR DESCRIPTION
# What changes?

Factor in emergency SNAP allotment waviers in many states, which gives states the ability to give each household the maximum benefit for their household size instead of the usual calculation. 

# Note

This state options data for emergency allotment is valid as of today, 4/1/2020, but will likely need to be updated regularly if more states apply for and receive waivers for emergency SNAP allotments. 

# Screenshot (new benefit explanation) 

For a hypothetical VT household: 

<img width="549" alt="Screen Shot 2020-04-01 at 11 23 14 AM" src="https://user-images.githubusercontent.com/3209501/78161829-a9c5db80-740b-11ea-838f-508108bd6043.png">

# Screenshot (IL/VT)

Vermont has received an emergency allotment waiver as of 4/1/2010, Illinois has not as of today. The screenshots below show how as of today, the same household would receive a very different estimated SNAP benefit if they lived in VT as opposed to IL:

<img width="1439" alt="Screen Shot 2020-04-01 at 11 23 27 AM" src="https://user-images.githubusercontent.com/3209501/78161869-b6e2ca80-740b-11ea-8b4c-4d264d69e9d7.png">
<img width="1434" alt="Screen Shot 2020-04-01 at 11 23 40 AM" src="https://user-images.githubusercontent.com/3209501/78161880-b9452480-740b-11ea-83ec-aea13839627c.png">
